### PR TITLE
Move MCP protocol types from type_helpers.h to types.h

### DIFF
--- a/include/mcp/type_helpers.h
+++ b/include/mcp/type_helpers.h
@@ -22,10 +22,7 @@ struct Tool;
 struct Prompt;
 struct Error;
 
-// Type aliases for common patterns
-using RequestId = variant<std::string, int>;
-using ProgressToken = variant<std::string, int>;
-using Cursor = std::string;
+// Protocol types are defined in types.h
 
 // CTAD alternatives - Factory functions that deduce template parameters
 
@@ -43,29 +40,7 @@ constexpr optional<T> none() {
 }
 
 // For variant types - extend make_variant for common MCP patterns
-// RequestId factory
-inline RequestId make_request_id(const std::string& id) {
-  return RequestId(id);
-}
-
-inline RequestId make_request_id(int id) { return RequestId(id); }
-
-inline RequestId make_request_id(const char* id) {
-  return RequestId(std::string(id));
-}
-
-// ProgressToken factory
-inline ProgressToken make_progress_token(const std::string& token) {
-  return ProgressToken(token);
-}
-
-inline ProgressToken make_progress_token(int token) {
-  return ProgressToken(token);
-}
-
-inline ProgressToken make_progress_token(const char* token) {
-  return ProgressToken(std::string(token));
-}
+// Protocol type factory functions moved to types.h
 
 // Content block factories - these will be defined in types.h after the types
 // are complete
@@ -141,101 +116,9 @@ auto make_method_notification(const std::string& method, T&& params)
       method, std::forward<T>(params));
 }
 
-template <typename T>
-auto make_method_request(const RequestId& id,
-                         const std::string& method,
-                         T&& params)
-    -> std::pair<RequestId, MethodDiscriminator<typename std::decay<T>::type>> {
-  return std::make_pair(
-      id, MethodDiscriminator<typename std::decay<T>::type>::create(
-              method, std::forward<T>(params)));
-}
+// make_method_request moved to types.h as it depends on RequestId
 
-// Enum helpers for string literal enums
-namespace enums {
-
-// Role enum
-struct Role {
-  enum Value { USER, ASSISTANT };
-
-  static const char* to_string(Value v) {
-    switch (v) {
-      case USER:
-        return "user";
-      case ASSISTANT:
-        return "assistant";
-      default:
-        return "";
-    }
-  }
-
-  static optional<Value> from_string(const std::string& s) {
-    if (s == "user")
-      return make_optional(USER);
-    if (s == "assistant")
-      return make_optional(ASSISTANT);
-    return nullopt;
-  }
-};
-
-// LoggingLevel enum with all RFC-5424 severities
-struct LoggingLevel {
-  enum Value {
-    DEBUG = 0,     // Debug-level messages
-    INFO = 1,      // Informational messages
-    NOTICE = 2,    // Normal but significant condition
-    WARNING = 3,   // Warning conditions
-    ERROR = 4,     // Error conditions
-    CRITICAL = 5,  // Critical conditions
-    ALERT = 6,     // Action must be taken immediately
-    EMERGENCY = 7  // System is unusable
-  };
-
-  static const char* to_string(Value v) {
-    switch (v) {
-      case DEBUG:
-        return "debug";
-      case INFO:
-        return "info";
-      case NOTICE:
-        return "notice";
-      case WARNING:
-        return "warning";
-      case ERROR:
-        return "error";
-      case CRITICAL:
-        return "critical";
-      case ALERT:
-        return "alert";
-      case EMERGENCY:
-        return "emergency";
-      default:
-        return "";
-    }
-  }
-
-  static optional<Value> from_string(const std::string& s) {
-    if (s == "debug")
-      return make_optional(DEBUG);
-    if (s == "info")
-      return make_optional(INFO);
-    if (s == "notice")
-      return make_optional(NOTICE);
-    if (s == "warning")
-      return make_optional(WARNING);
-    if (s == "error")
-      return make_optional(ERROR);
-    if (s == "critical")
-      return make_optional(CRITICAL);
-    if (s == "alert")
-      return make_optional(ALERT);
-    if (s == "emergency")
-      return make_optional(EMERGENCY);
-    return nullopt;
-  }
-};
-
-}  // namespace enums
+// Enum helpers moved to types.h for protocol consistency
 
 // Extensible metadata pattern for [key: string]: unknown
 using Metadata = std::map<


### PR DESCRIPTION
Following the TypeScript schema's single-file structure, consolidate all MCP protocol types into types.h:
- Move RequestId, ProgressToken, Cursor type aliases
- Move Role and LoggingLevel enums (including enums namespace)
- Move related factory functions (make_request_id, make_progress_token)
- Move make_method_request which depends on RequestId

Keep only true C++ implementation helpers in type_helpers.h:
- CTAD alternatives and generic helpers
- TypeDiscriminator, MethodDiscriminator templates
- Metadata utilities, ObjectBuilder, string_literal
- Other generic C++ utilities

This separation ensures protocol types follow the schema structure while keeping implementation-specific helpers separate.