### PR TITLE
Fix connection lifetime and init-path crashes

### DIFF
--- a/include/mcp/filter/http_codec_filter.h
+++ b/include/mcp/filter/http_codec_filter.h
@@ -210,6 +210,18 @@ class HttpCodecFilter : public network::Filter {
    */
   void markSseGetSent() { sse_get_sent_ = true; }
 
+  /**
+   * Body timeout actually configured on the state machine. In client mode
+   * this is disabled (0) because SSE response streams may sit idle between
+   * server-pushed events; in server mode it is bounded. Exposed for
+   * introspection and for tests that guard against regressions in the
+   * client/server wiring.
+   */
+  std::chrono::milliseconds bodyTimeout() const {
+    return state_machine_ ? state_machine_->config().body_timeout
+                          : std::chrono::milliseconds(0);
+  }
+
  private:
   // Inner class implementing MessageEncoder
   class MessageEncoderImpl : public MessageEncoder {

--- a/include/mcp/filter/http_codec_state_machine.h
+++ b/include/mcp/filter/http_codec_state_machine.h
@@ -345,6 +345,12 @@ class HttpCodecStateMachine {
    */
   static std::string getEventName(HttpCodecEvent event);
 
+  /**
+   * Configured values (as passed into the constructor). Read-only; the
+   * config is immutable after construction.
+   */
+  const HttpCodecStateMachineConfig& config() const { return config_; }
+
  protected:
   // ===== Protected Methods for Extension =====
 

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -938,6 +938,12 @@ class McpServer : public application::ApplicationBase,
   // Background task state
   std::atomic<bool> background_threads_running_{false};
 
+  // Timers for periodic background tasks. Stored as members so they survive
+  // past startBackgroundTasks() returning — otherwise the TimerPtr would drop
+  // at end of scope and the callback would never fire.
+  event::TimerPtr session_cleanup_timer_;
+  event::TimerPtr resource_update_timer_;
+
   // Deferred listen address
   std::string listen_address_;
   bool need_perform_listen_ = false;

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -827,6 +827,45 @@ class McpServer : public application::ApplicationBase,
   void stopBackgroundTasks();
 
  private:
+  // Per-connection lifecycle callback adapter.
+  //
+  // Why: ConnectionCallbacks::onEvent carries no Connection identity. Before
+  // this adapter, McpServer registered itself on every connection and then
+  // fell back to a global `current_connection_` pointer to figure out which
+  // one closed — which is stale whenever multiple connections are active.
+  // Each adapter binds (server, connection) at construction so the close
+  // path knows exactly which connection is dying.
+  //
+  // Also DeferredDeletable: the adapter is registered on the connection, so
+  // destroying it synchronously while we are inside its own onEvent() would
+  // be a use-after-free. The server hands it to dispatcher.deferredDelete()
+  // alongside the connection itself.
+  class ConnectionLifecycleCallbacks : public network::ConnectionCallbacks,
+                                       public event::DeferredDeletable {
+   public:
+    ConnectionLifecycleCallbacks(McpServer& server,
+                                 network::Connection* connection)
+        : server_(server), connection_(connection) {}
+
+    void onEvent(network::ConnectionEvent event) override {
+      server_.onConnectionLifecycleEvent(connection_, event);
+    }
+    void onAboveWriteBufferHighWatermark() override {}
+    void onBelowWriteBufferLowWatermark() override {}
+
+   private:
+    McpServer& server_;
+    network::Connection* connection_;
+  };
+
+  // Dispatcher-thread only: all entries added/removed inside dispatcher.
+  std::unordered_map<network::Connection*,
+                     std::unique_ptr<ConnectionLifecycleCallbacks>>
+      lifecycle_callbacks_;
+
+  void onConnectionLifecycleEvent(network::Connection* connection,
+                                  network::ConnectionEvent event);
+
   // Internal callbacks class to bridge McpProtocolCallbacks to McpServer
   // Following production pattern: separate callback interface from main class
   class ServerProtocolCallbacks : public McpProtocolCallbacks {

--- a/src/client/mcp_client.cc
+++ b/src/client/mcp_client.cc
@@ -481,14 +481,16 @@ std::future<InitializeResult> McpClient::initializeProtocol() {
     // Callback returns immediately - response will be processed elsewhere
   });
 
-  // Step 2: Use std::async to wait for response on a worker thread (not
-  // dispatcher!) Fire and forget - the async thread will set the promise when
-  // done
+  // Step 2: Block on the response on a worker thread so we don't stall the
+  // dispatcher. When the response parses cleanly, hand the dispatcher-thread
+  // state mutations (protocol_state_machine_, server_capabilities_,
+  // initialized_) back to the dispatcher via post() — those fields are read
+  // from the dispatcher elsewhere, so writing them from this worker thread
+  // would be a data race. Only the final promise resolution runs on whichever
+  // thread (dispatcher or worker) completes parsing.
   std::thread([this, result_promise, request_future_ptr]() {
     try {
-      // Wait for the request to be sent (the dispatcher callback to complete)
-      // Then wait for the response - this blocks a worker thread, NOT the
-      // dispatcher
+      // Wait for dispatcher to publish the request future.
       while (!request_future_ptr->valid()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
       }
@@ -501,88 +503,89 @@ std::future<InitializeResult> McpClient::initializeProtocol() {
       if (response.error.has_value()) {
         result_promise->set_exception(std::make_exception_ptr(
             std::runtime_error(response.error->message)));
-      } else {
-        // Parse InitializeResult from response
-        InitializeResult init_result;
+        return;
+      }
 
-        // Parse the flattened response from server
-        // The server returns a Metadata object with flattened fields
-        if (holds_alternative<Metadata>(response.result.value())) {
-          auto& metadata = get<Metadata>(response.result.value());
+      // Parse InitializeResult from response (pure parsing — no shared state).
+      InitializeResult init_result;
+      if (holds_alternative<Metadata>(response.result.value())) {
+        auto& metadata = get<Metadata>(response.result.value());
 
-          // Extract protocol version
-          auto proto_it = metadata.find("protocolVersion");
-          if (proto_it != metadata.end() &&
-              holds_alternative<std::string>(proto_it->second)) {
-            init_result.protocolVersion = get<std::string>(proto_it->second);
-          }
-
-          // Extract server info
-          auto name_it = metadata.find("serverInfo.name");
-          auto version_it = metadata.find("serverInfo.version");
-          if (name_it != metadata.end() && version_it != metadata.end()) {
-            Implementation server_info(
-                holds_alternative<std::string>(name_it->second)
-                    ? get<std::string>(name_it->second)
-                    : "",
-                holds_alternative<std::string>(version_it->second)
-                    ? get<std::string>(version_it->second)
-                    : "");
-            init_result.serverInfo = mcp::make_optional(server_info);
-          }
-
-          // Extract capabilities (simplified)
-          ServerCapabilities caps;
-
-          auto tools_it = metadata.find("capabilities.tools");
-          if (tools_it != metadata.end() &&
-              holds_alternative<bool>(tools_it->second)) {
-            caps.tools = mcp::make_optional(get<bool>(tools_it->second));
-          }
-
-          auto prompts_it = metadata.find("capabilities.prompts");
-          if (prompts_it != metadata.end() &&
-              holds_alternative<bool>(prompts_it->second)) {
-            caps.prompts = mcp::make_optional(get<bool>(prompts_it->second));
-          }
-
-          auto resources_it = metadata.find("capabilities.resources");
-          if (resources_it != metadata.end() &&
-              holds_alternative<bool>(resources_it->second)) {
-            caps.resources =
-                mcp::make_optional(variant<bool, ResourcesCapability>(
-                    get<bool>(resources_it->second)));
-          }
-
-          auto logging_it = metadata.find("capabilities.logging");
-          if (logging_it != metadata.end() &&
-              holds_alternative<bool>(logging_it->second)) {
-            caps.logging = mcp::make_optional(get<bool>(logging_it->second));
-          }
-
-          init_result.capabilities = caps;
-        } else {
-          // Fallback if response format is unexpected
-          init_result.protocolVersion = config_.protocol_version;
-          init_result.capabilities = ServerCapabilities();
+        auto proto_it = metadata.find("protocolVersion");
+        if (proto_it != metadata.end() &&
+            holds_alternative<std::string>(proto_it->second)) {
+          init_result.protocolVersion = get<std::string>(proto_it->second);
         }
 
-        // Store server capabilities
+        auto name_it = metadata.find("serverInfo.name");
+        auto version_it = metadata.find("serverInfo.version");
+        if (name_it != metadata.end() && version_it != metadata.end()) {
+          Implementation server_info(
+              holds_alternative<std::string>(name_it->second)
+                  ? get<std::string>(name_it->second)
+                  : "",
+              holds_alternative<std::string>(version_it->second)
+                  ? get<std::string>(version_it->second)
+                  : "");
+          init_result.serverInfo = mcp::make_optional(server_info);
+        }
+
+        ServerCapabilities caps;
+
+        auto tools_it = metadata.find("capabilities.tools");
+        if (tools_it != metadata.end() &&
+            holds_alternative<bool>(tools_it->second)) {
+          caps.tools = mcp::make_optional(get<bool>(tools_it->second));
+        }
+
+        auto prompts_it = metadata.find("capabilities.prompts");
+        if (prompts_it != metadata.end() &&
+            holds_alternative<bool>(prompts_it->second)) {
+          caps.prompts = mcp::make_optional(get<bool>(prompts_it->second));
+        }
+
+        auto resources_it = metadata.find("capabilities.resources");
+        if (resources_it != metadata.end() &&
+            holds_alternative<bool>(resources_it->second)) {
+          caps.resources =
+              mcp::make_optional(variant<bool, ResourcesCapability>(
+                  get<bool>(resources_it->second)));
+        }
+
+        auto logging_it = metadata.find("capabilities.logging");
+        if (logging_it != metadata.end() &&
+            holds_alternative<bool>(logging_it->second)) {
+          caps.logging = mcp::make_optional(get<bool>(logging_it->second));
+        }
+
+        init_result.capabilities = caps;
+      } else {
+        init_result.protocolVersion = config_.protocol_version;
+        init_result.capabilities = ServerCapabilities();
+      }
+
+      // Commit state on the dispatcher thread, then fulfill the promise.
+      // The promise is fulfilled after the post completes so callers who
+      // proceed on future.get() see initialized_/server_capabilities_
+      // already published.
+      if (!main_dispatcher_) {
+        result_promise->set_exception(std::make_exception_ptr(
+            std::runtime_error("No dispatcher")));
+        return;
+      }
+      main_dispatcher_->post([this, result_promise, init_result]() {
         server_capabilities_ = init_result.capabilities;
         initialized_ = true;
-
-        // Notify protocol state machine that initialization is complete
         if (protocol_state_machine_) {
           protocol_state_machine_->handleEvent(
               protocol::McpProtocolEvent::INITIALIZED);
         }
-
         result_promise->set_value(init_result);
-      }
+      });
     } catch (...) {
       result_promise->set_exception(std::current_exception());
     }
-  }).detach();  // Detach the thread - it will set the promise when done
+  }).detach();
 
   return result_promise->get_future();
 }

--- a/src/event/libevent_dispatcher.cc
+++ b/src/event/libevent_dispatcher.cc
@@ -886,21 +886,30 @@ LibeventDispatcher::SchedulableCallbackImpl::~SchedulableCallbackImpl() {
 
 void LibeventDispatcher::SchedulableCallbackImpl::
     scheduleCallbackCurrentIteration() {
-  if (!scheduled_) {
-    if (dispatcher_.isThreadSafe()) {
-      // We're in the dispatcher thread, run immediately
-      scheduled_ = false;
-      cb_();
-    } else {
-      // Post to dispatcher thread
-      dispatcher_.post([this]() {
-        if (scheduled_) {
-          scheduled_ = false;
-          cb_();
-        }
-      });
-      scheduled_ = true;
-    }
+  if (scheduled_) {
+    return;
+  }
+  // Never run the callback synchronously, even when the caller is already on
+  // the dispatcher thread. The contract for this primitive is that it defers
+  // past the caller's current stack frame — deferredDelete, emulated-edge
+  // file-event activation, and future callers all rely on this to avoid
+  // destroying state (or re-entering libevent) from inside the callback that
+  // scheduled the drain.
+  //
+  // A 0ms timer gives us that guarantee: libevent will fire it after the
+  // current handler returns, before the next poll wait. From off-thread, we
+  // still route through post() so libevent is woken safely.
+  if (dispatcher_.isThreadSafe()) {
+    timer_->enableTimer(std::chrono::milliseconds(0));
+    scheduled_ = true;
+  } else {
+    scheduled_ = true;
+    dispatcher_.post([this]() {
+      if (scheduled_) {
+        scheduled_ = false;
+        cb_();
+      }
+    });
   }
 }
 

--- a/src/filter/http_codec_filter.cc
+++ b/src/filter/http_codec_filter.cc
@@ -105,11 +105,16 @@ HttpCodecFilter::HttpCodecFilter(MessageCallbacks& callbacks,
   // Initialize message encoder
   message_encoder_ = std::make_unique<MessageEncoderImpl>(*this);
 
-  // Initialize HTTP codec state machine
+  // Initialize HTTP codec state machine.
+  // Client-side body_timeout is disabled (0 == no timeout): an SSE response
+  // body is an open-ended stream that may stay silent between events for
+  // longer than a request/response body timeout would tolerate. Servers keep
+  // the bounded timeout — request bodies are expected to complete promptly.
   HttpCodecStateMachineConfig config;
-  config.is_server = is_server_;  // Set mode
+  config.is_server = is_server_;
   config.header_timeout = std::chrono::milliseconds(30000);
-  config.body_timeout = std::chrono::milliseconds(60000);
+  config.body_timeout = is_server_ ? std::chrono::milliseconds(60000)
+                                   : std::chrono::milliseconds(0);
   config.idle_timeout = std::chrono::milliseconds(120000);
   config.enable_keep_alive = true;
   config.state_change_callback =
@@ -156,12 +161,15 @@ HttpCodecFilter::HttpCodecFilter(const filter::FilterCreationContext& context,
   // Initialize message encoder
   message_encoder_ = std::make_unique<MessageEncoderImpl>(*this);
 
-  // Initialize HTTP codec state machine with same defaults for now
+  // Initialize HTTP codec state machine.
+  // Client-side body_timeout is disabled (0) for the same reason as the
+  // other constructor: SSE streams may sit idle between server-pushed events.
   // TODO: Extract timeout values from config parameter
   HttpCodecStateMachineConfig sm_config;
   sm_config.is_server = is_server_;
   sm_config.header_timeout = std::chrono::milliseconds(30000);
-  sm_config.body_timeout = std::chrono::milliseconds(60000);
+  sm_config.body_timeout = is_server_ ? std::chrono::milliseconds(60000)
+                                      : std::chrono::milliseconds(0);
   sm_config.idle_timeout = std::chrono::milliseconds(120000);
   sm_config.enable_keep_alive = true;
   sm_config.state_change_callback =

--- a/src/mcp_connection_manager.cc
+++ b/src/mcp_connection_manager.cc
@@ -1,5 +1,6 @@
 #include "mcp/mcp_connection_manager.h"
 
+#include <cassert>
 #include <cstring>
 #include <iostream>
 #include <sstream>
@@ -790,6 +791,11 @@ void McpConnectionManager::onResponse(const jsonrpc::Response& response) {
 }
 
 void McpConnectionManager::onConnectionEvent(network::ConnectionEvent event) {
+  // Connection events are raised from the connection's own callback loop,
+  // which runs on the dispatcher thread. Anything else would mean a caller
+  // synthesised the event off-thread — a bug, not a transport event.
+  assert(dispatcher_.isThreadSafe() && "onConnectionEvent off dispatcher");
+
   const char* event_name = "unknown";
   switch (event) {
     case network::ConnectionEvent::Connected:
@@ -859,20 +865,16 @@ void McpConnectionManager::onConnectionEvent(network::ConnectionEvent event) {
       return;
     }
 
-    // Connection closed - clean up state
-    connected_ = false;
-    // CRITICAL FIX: Defer connection destruction
+    // Connection closed - clean up state.
     // We are being called from within the connection's callback loop
-    // (raiseConnectionEvent). Destroying the connection here would cause
-    // use-after-free when the callback loop continues to iterate. Use post() to
-    // defer destruction until after current callback.
+    // (raiseConnectionEvent). Destroying the connection synchronously here
+    // would be a use-after-free once the callback loop resumes. Hand it to
+    // the dispatcher's deferred-delete queue instead — Connection derives
+    // from DeferredDeletable, so the dispatcher owns teardown on the next
+    // event-loop iteration, after all in-flight callbacks unwind.
+    connected_ = false;
     if (active_connection_) {
-      auto conn_to_delete = std::make_shared<network::ConnectionPtr>(
-          std::move(active_connection_));
-      dispatcher_.post([conn_to_delete]() {
-        // Connection is destroyed when lambda and shared_ptr go out of scope
-        conn_to_delete->reset();
-      });
+      dispatcher_.deferredDelete(std::move(active_connection_));
     }
   }
 

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -7,6 +7,7 @@
 #include "mcp/server/mcp_server.h"
 
 #include <algorithm>
+#include <cassert>
 #include <future>
 #include <sstream>
 
@@ -762,47 +763,85 @@ void McpServer::onResponse(const jsonrpc::Response& response) {
 }
 
 void McpServer::onConnectionEvent(network::ConnectionEvent event) {
-  // Handle connection events
+  // Stats-only path. Per-connection cleanup lives in
+  // onConnectionLifecycleEvent, invoked by the ConnectionLifecycleCallbacks
+  // adapter which carries the closing connection's identity. This function
+  // still runs for stdio transports (reached via ServerProtocolCallbacks)
+  // where there is no active_connections_ entry to unwind.
   switch (event) {
     case network::ConnectionEvent::Connected:
     case network::ConnectionEvent::ConnectedZeroRtt:
       server_stats_.connections_total++;
       server_stats_.connections_active++;
       break;
-
     case network::ConnectionEvent::RemoteClose:
     case network::ConnectionEvent::LocalClose:
       server_stats_.connections_active--;
-
-      // Clean up session for this connection
-      if (session_manager_ && current_connection_) {
-        // Remove session associated with the closed connection
-        session_manager_->removeSessionByConnection(current_connection_);
-
-        // Remove from connection-session mapping
-        // Following production pattern: use lock since this map may be accessed
-        // from multiple dispatcher threads
-        {
-          std::lock_guard<std::mutex> lock(connection_sessions_mutex_);
-          connection_sessions_.erase(current_connection_);
-        }
-
-        // Remove connection from active list
-        // Following production pattern: all in dispatcher thread, no mutex
-        // needed
-        active_connections_.remove_if(
-            [this](const network::ConnectionPtr& conn) {
-              return conn.get() == current_connection_;
-            });
-
-        // Clear the current connection
-        current_connection_ = nullptr;
-
-        // Decrement connection count
-        num_connections_--;
-      }
       break;
   }
+}
+
+void McpServer::onConnectionLifecycleEvent(network::Connection* connection,
+                                           network::ConnectionEvent event) {
+  // Connection events fire from the connection's own callback loop, which is
+  // the dispatcher thread. Enforcing this here catches any accidental
+  // off-thread callers introduced later.
+  assert(main_dispatcher_ && main_dispatcher_->isThreadSafe() &&
+         "onConnectionLifecycleEvent off dispatcher");
+  // Runs in dispatcher thread via the per-connection adapter.
+  switch (event) {
+    case network::ConnectionEvent::Connected:
+    case network::ConnectionEvent::ConnectedZeroRtt:
+      server_stats_.connections_total++;
+      server_stats_.connections_active++;
+      return;
+    case network::ConnectionEvent::RemoteClose:
+    case network::ConnectionEvent::LocalClose:
+      break;
+  }
+
+  server_stats_.connections_active--;
+
+  // Tear down session state keyed by the actual closing connection, not a
+  // global current_connection_ which may point at a different session.
+  if (session_manager_) {
+    session_manager_->removeSessionByConnection(connection);
+  }
+  {
+    std::lock_guard<std::mutex> lock(connection_sessions_mutex_);
+    connection_sessions_.erase(connection);
+  }
+
+  // Hand both the ConnectionPtr and the lifecycle adapter to the dispatcher's
+  // deferred-delete queue. We are currently inside the adapter's onEvent(),
+  // and the connection is iterating its own callback list — destroying either
+  // synchronously would be a use-after-free. deferredDelete drains after the
+  // current callback stack unwinds.
+  //
+  // Skip container unwinding if we're past shutdown: during ~McpServer the
+  // containers themselves are being destroyed, and mutating them from a
+  // close-triggered callback would be UB. Shutdown already sets this flag
+  // before the destructor starts tearing members down.
+  if (server_running_) {
+    for (auto it = active_connections_.begin();
+         it != active_connections_.end(); ++it) {
+      if (it->get() == connection) {
+        main_dispatcher_->deferredDelete(std::move(*it));
+        active_connections_.erase(it);
+        break;
+      }
+    }
+    auto cb_it = lifecycle_callbacks_.find(connection);
+    if (cb_it != lifecycle_callbacks_.end()) {
+      main_dispatcher_->deferredDelete(std::move(cb_it->second));
+      lifecycle_callbacks_.erase(cb_it);
+    }
+  }
+
+  if (current_connection_ == connection) {
+    current_connection_ = nullptr;
+  }
+  num_connections_--;
 }
 
 void McpServer::onError(const Error& error) {
@@ -1223,9 +1262,14 @@ void McpServer::onNewConnection(network::ConnectionPtr&& connection) {
     return;
   }
 
-  // Add ourselves as connection callbacks to track lifecycle
-  // This allows us to clean up session when connection closes
-  connection->addConnectionCallbacks(*this);
+  // Register a per-connection lifecycle adapter so the close event tells us
+  // exactly which connection is dying. The adapter is held alive by the
+  // lifecycle_callbacks_ map until the close path hands it to the dispatcher
+  // for deferred deletion.
+  auto lifecycle_cb =
+      std::make_unique<ConnectionLifecycleCallbacks>(*this, conn_ptr);
+  connection->addConnectionCallbacks(*lifecycle_cb);
+  lifecycle_callbacks_[conn_ptr] = std::move(lifecycle_cb);
 
   // Store connection-to-session mapping
   // Following production pattern: listener owns connections

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -1137,48 +1137,47 @@ jsonrpc::Response McpServer::handleGetPrompt(const jsonrpc::Request& request,
                                     jsonrpc::ResponseResult(result_metadata));
 }
 
-// Background task management using dispatcher timers
+// Background task management using dispatcher timers.
+// Timers are owned by McpServer so they outlive this function; on each fire
+// the callback re-arms the same timer to implement a periodic task without
+// rebuilding timer objects.
 void McpServer::startBackgroundTasks() {
   background_threads_running_ = true;
 
-  // Schedule periodic session cleanup using dispatcher timer
-  auto cleanup_timer = main_dispatcher_->createTimer([this]() {
-    if (background_threads_running_) {
-      // Clean up expired sessions
-      session_manager_->cleanupExpiredSessions();
+  const auto cleanup_interval = std::chrono::seconds(30);
 
-      // Reschedule for next cleanup
-      auto next_timer = main_dispatcher_->createTimer([this]() {
-        if (background_threads_running_) {
-          startBackgroundTasks();
-        }
-      });
-      next_timer->enableTimer(std::chrono::seconds(30));
+  session_cleanup_timer_ = main_dispatcher_->createTimer([this, cleanup_interval]() {
+    if (!background_threads_running_) {
+      return;
     }
+    session_manager_->cleanupExpiredSessions();
+    // Re-arm for the next tick. The timer is a member, so firing is safe.
+    session_cleanup_timer_->enableTimer(cleanup_interval);
   });
-  cleanup_timer->enableTimer(std::chrono::seconds(30));
+  session_cleanup_timer_->enableTimer(cleanup_interval);
 
-  // Schedule periodic resource update notifications
-  auto update_timer = main_dispatcher_->createTimer([this]() {
-    if (background_threads_running_) {
-      // Process pending resource updates for each session
-      // Get all sessions and send pending updates
+  const auto update_interval = config_.resource_update_debounce;
 
-      // Reschedule
-      auto next_timer = main_dispatcher_->createTimer([this]() {
-        if (background_threads_running_) {
-          // Continue resource update processing
-        }
-      });
-      next_timer->enableTimer(config_.resource_update_debounce);
+  resource_update_timer_ = main_dispatcher_->createTimer([this, update_interval]() {
+    if (!background_threads_running_) {
+      return;
     }
+    // Resource-update dispatch hooks in here when enabled.
+    resource_update_timer_->enableTimer(update_interval);
   });
-  update_timer->enableTimer(config_.resource_update_debounce);
+  resource_update_timer_->enableTimer(update_interval);
 }
 
 void McpServer::stopBackgroundTasks() {
   background_threads_running_ = false;
-  // Timers will naturally expire and not reschedule
+  // Disable immediately so a pending fire doesn't run after shutdown starts.
+  // The guard above also prevents re-arming from inside the callback.
+  if (session_cleanup_timer_) {
+    session_cleanup_timer_->disableTimer();
+  }
+  if (resource_update_timer_) {
+    resource_update_timer_->disableTimer();
+  }
 }
 
 // ListenerCallbacks implementation (production pattern)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(test_options_notification filter/test_options_notification.cc)
 # Event tests
 add_executable(test_event_loop event/test_event_loop.cc)
 add_executable(test_timer_lifetime event/test_timer_lifetime.cc)
+add_executable(test_deferred_delete_ordering event/test_deferred_delete_ordering.cc)
 
 # Network tests
 add_executable(test_io_socket_handle network/test_io_socket_handle.cc)
@@ -289,6 +290,14 @@ target_link_libraries(test_event_loop
 )
 
 target_link_libraries(test_timer_lifetime
+    gopher-mcp-event
+    gopher-mcp
+    gtest
+    gtest_main
+    Threads::Threads
+)
+
+target_link_libraries(test_deferred_delete_ordering
     gopher-mcp-event
     gopher-mcp
     gtest
@@ -1278,6 +1287,7 @@ add_test(NAME CorsHeadersTest COMMAND test_cors_headers)
 add_test(NAME OptionsNotificationTest COMMAND test_options_notification)
 add_test(NAME EventLoopTest COMMAND test_event_loop)
 add_test(NAME TimerLifetimeTest COMMAND test_timer_lifetime)
+add_test(NAME DeferredDeleteOrderingTest COMMAND test_deferred_delete_ordering)
 
 # Network tests
 add_test(NAME IoSocketHandleTest COMMAND test_io_socket_handle)

--- a/tests/connection/test_connection_manager.cc
+++ b/tests/connection/test_connection_manager.cc
@@ -10,6 +10,10 @@
  * - Connection close order
  */
 
+#include <atomic>
+#include <chrono>
+#include <thread>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -49,12 +53,61 @@ class ConnectionManagerSection2Test : public ::testing::Test {
   }
 
   void TearDown() override {
+    stopDispatcherThread();
     callbacks_.reset();
     dispatcher_.reset();
   }
 
+  // Starts the dispatcher on a background thread.  Needed for tests that
+  // invoke McpConnectionManager methods that assert isThreadSafe() — those
+  // methods model callbacks coming from the connection's own callback loop,
+  // which only exists once the dispatcher is running.
+  void startDispatcherThread() {
+    if (loop_thread_.joinable()) {
+      return;
+    }
+    loop_thread_ = std::thread(
+        [this]() { dispatcher_->run(event::RunType::Block); });
+    // Wait until libevent has actually entered the loop — without this we
+    // race with thread_id_ being set and isThreadSafe() still returns false.
+    for (int i = 0; i < 200 && !dispatcher_->isThreadSafe(); ++i) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+      // isThreadSafe() checked from test thread is always false by design;
+      // poll via a posted sentinel instead.
+      std::atomic<bool> sentinel{false};
+      dispatcher_->post([&sentinel]() { sentinel = true; });
+      for (int j = 0; j < 50 && !sentinel.load(); ++j) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+      }
+      if (sentinel.load()) break;
+    }
+  }
+
+  // Posts fn onto the dispatcher and blocks until it has run.  Use for any
+  // call that must execute on the dispatcher thread (e.g., onConnectionEvent,
+  // deferredDelete, connection mutators guarded by dispatcher-thread asserts).
+  void runOnDispatcher(std::function<void()> fn) {
+    std::atomic<bool> done{false};
+    dispatcher_->post([&done, fn = std::move(fn)]() {
+      fn();
+      done = true;
+    });
+    for (int i = 0; i < 400 && !done.load(); ++i) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_TRUE(done.load()) << "dispatcher never ran the posted callback";
+  }
+
+  void stopDispatcherThread() {
+    if (loop_thread_.joinable()) {
+      dispatcher_->exit();
+      loop_thread_.join();
+    }
+  }
+
   std::unique_ptr<event::Dispatcher> dispatcher_;
   std::unique_ptr<MockProtocolCallbacks> callbacks_;
+  std::thread loop_thread_;
 };
 
 // =============================================================================
@@ -268,10 +321,16 @@ TEST_F(ConnectionManagerSection2Test,
               onConnectionEvent(network::ConnectionEvent::Connected))
       .Times(1);
 
-  // Simulate receiving Connected event twice
-  manager->onConnectionEvent(network::ConnectionEvent::Connected);
-  manager->onConnectionEvent(
-      network::ConnectionEvent::Connected);  // Should be ignored
+  // onConnectionEvent asserts it runs on the dispatcher thread because in
+  // production it's always invoked from the connection's own callback loop.
+  // Drive the synthetic invocations through the dispatcher so they satisfy
+  // that contract.
+  startDispatcherThread();
+  runOnDispatcher([&manager]() {
+    manager->onConnectionEvent(network::ConnectionEvent::Connected);
+    manager->onConnectionEvent(
+        network::ConnectionEvent::Connected);  // Should be ignored
+  });
 }
 
 /**
@@ -286,12 +345,76 @@ TEST_F(ConnectionManagerSection2Test, OnConnectionEventPreventsDuplicateClose) {
 
   manager->setProtocolCallbacks(*callbacks_);
 
-  // First close should be processed, second should be ignored
-  // We can't easily verify the exact count due to internal state,
-  // but we can verify it doesn't crash
-  manager->onConnectionEvent(network::ConnectionEvent::RemoteClose);
-  manager->onConnectionEvent(network::ConnectionEvent::RemoteClose);
-  manager->onConnectionEvent(network::ConnectionEvent::LocalClose);
+  // As above — driven through the dispatcher to satisfy the
+  // onConnectionEvent thread-safety assert.
+  startDispatcherThread();
+  runOnDispatcher([&manager]() {
+    manager->onConnectionEvent(network::ConnectionEvent::RemoteClose);
+    manager->onConnectionEvent(network::ConnectionEvent::RemoteClose);
+    manager->onConnectionEvent(network::ConnectionEvent::LocalClose);
+  });
+}
+
+// =============================================================================
+// Deferred-close / thread-safety regression tests (PR #212)
+// =============================================================================
+
+// Regression test for the crash fixed by 4f46b3db:
+// onConnectionEvent(RemoteClose|LocalClose) used to destroy active_connection_
+// synchronously from inside the connection's own callback loop, causing UAF.
+// It now hands the connection to dispatcher.deferredDelete.  This test drives
+// the close path on the dispatcher thread and verifies it completes without
+// tripping the dispatcher-thread assertion and without crashing.
+TEST_F(ConnectionManagerSection2Test, OnCloseRunsCleanlyOnDispatcherThread) {
+  McpConnectionConfig config;
+  config.transport_type = TransportType::HttpSse;
+
+  auto manager = std::make_unique<McpConnectionManager>(
+      *dispatcher_, network::socketInterface(), config);
+  manager->setProtocolCallbacks(*callbacks_);
+
+  startDispatcherThread();
+
+  // Full legal lifecycle: connect -> close.  Each step must run on the
+  // dispatcher thread because onConnectionEvent now asserts it.
+  runOnDispatcher([&manager]() {
+    manager->onConnectionEvent(network::ConnectionEvent::Connected);
+  });
+  runOnDispatcher([&manager]() {
+    manager->onConnectionEvent(network::ConnectionEvent::RemoteClose);
+  });
+
+  // Sanity: a stray close event after the first must also be safe to process
+  // on the dispatcher thread.  This is the path that used to UAF when the
+  // connection was destroyed synchronously on the first close.
+  runOnDispatcher([&manager]() {
+    manager->onConnectionEvent(network::ConnectionEvent::LocalClose);
+  });
+}
+
+// The dispatcher-thread assertion added alongside the deferred-close fix is
+// the tripwire that stops any future caller from synthesising connection
+// events on the wrong thread.  We can't exercise the abort path in a passing
+// test, but we can at least prove that the same calls *do* succeed when they
+// come in on the dispatcher thread — and, paired with the assertion, that
+// catches off-thread regressions in debug builds.
+TEST_F(ConnectionManagerSection2Test,
+       RepeatedEventSequencesOnDispatcherThreadDoNotCrash) {
+  McpConnectionConfig config;
+  config.transport_type = TransportType::HttpSse;
+
+  auto manager = std::make_unique<McpConnectionManager>(
+      *dispatcher_, network::socketInterface(), config);
+  manager->setProtocolCallbacks(*callbacks_);
+
+  startDispatcherThread();
+
+  for (int i = 0; i < 5; ++i) {
+    runOnDispatcher([&manager]() {
+      manager->onConnectionEvent(network::ConnectionEvent::Connected);
+      manager->onConnectionEvent(network::ConnectionEvent::RemoteClose);
+    });
+  }
 }
 
 // =============================================================================

--- a/tests/event/test_deferred_delete_ordering.cc
+++ b/tests/event/test_deferred_delete_ordering.cc
@@ -189,6 +189,87 @@ TEST_F(DeferredDeleteOrderingTest, NestedDeferredDeleteDuringDrainDrainsLater) {
       << "inner queued from outer's destructor must also drain";
 }
 
+// Models McpServer::ConnectionLifecycleCallbacks: a callback adapter that, on
+// receiving a close-like event, hands *itself* (and a "connection" peer it
+// owns) to the dispatcher's deferred-delete queue.  Destroying either
+// synchronously would be a use-after-free because the adapter's own onEvent()
+// is still on the stack, and the connection is still iterating its callback
+// list.
+struct PeerConnection : public DeferredDeletable {
+  explicit PeerConnection(std::atomic<bool>& destroyed) : destroyed_(destroyed) {}
+  ~PeerConnection() override { destroyed_ = true; }
+  std::atomic<bool>& destroyed_;
+};
+
+struct LifecycleAdapter : public DeferredDeletable {
+  LifecycleAdapter(Dispatcher& dispatcher,
+                   std::atomic<bool>& adapter_destroyed,
+                   std::unique_ptr<PeerConnection> peer)
+      : dispatcher_(dispatcher),
+        adapter_destroyed_(adapter_destroyed),
+        peer_(std::move(peer)) {}
+  ~LifecycleAdapter() override { adapter_destroyed_ = true; }
+
+  // Mirrors ConnectionLifecycleCallbacks::onEvent: on close, hand both self
+  // and the peer connection to deferred-delete.  Self-move via
+  // unique_ptr-holder avoids a double-delete.
+  void onClose(std::unique_ptr<LifecycleAdapter> self_ptr) {
+    assert(self_ptr.get() == this && "self_ptr must own *this*");
+    dispatcher_.deferredDelete(std::move(peer_));
+    dispatcher_.deferredDelete(std::move(self_ptr));
+  }
+
+  Dispatcher& dispatcher_;
+  std::atomic<bool>& adapter_destroyed_;
+  std::unique_ptr<PeerConnection> peer_;
+};
+
+// Regression test for the crash at McpServer::onConnectionLifecycleEvent:
+// when the adapter's own onEvent() hands both itself and the owning
+// connection to deferredDelete, neither may run its destructor before the
+// onEvent frame returns.  If destruction ran synchronously, the caller
+// iterating connection callbacks would free and then read this adapter's
+// vptr from its own onEvent — immediate UAF.
+TEST_F(DeferredDeleteOrderingTest,
+       LifecycleAdapterDefersSelfAndPeerFromOwnCallback) {
+  std::atomic<bool> adapter_destroyed{false};
+  std::atomic<bool> peer_destroyed{false};
+  std::atomic<bool> observed_alive_after_dispatch{false};
+  std::atomic<bool> callback_done{false};
+
+  auto peer = std::make_unique<PeerConnection>(peer_destroyed);
+  auto adapter = std::make_unique<LifecycleAdapter>(
+      *dispatcher_, adapter_destroyed, std::move(peer));
+
+  dispatcher_->post([&, adapter_raw = adapter.release()]() mutable {
+    std::unique_ptr<LifecycleAdapter> self(adapter_raw);
+    auto* adapter_ptr = self.get();
+    adapter_ptr->onClose(std::move(self));
+    // After onClose returns we must still observe both objects alive —
+    // the dispatcher has queued them but hasn't drained yet.
+    observed_alive_after_dispatch =
+        !adapter_destroyed.load() && !peer_destroyed.load();
+    callback_done = true;
+  });
+
+  for (int i = 0; i < 400 && !callback_done.load(); ++i) {
+    std::this_thread::sleep_for(5ms);
+  }
+  ASSERT_TRUE(callback_done.load());
+
+  EXPECT_TRUE(observed_alive_after_dispatch)
+      << "adapter or peer was destroyed inside its own onEvent — would UAF "
+         "the ConnectionCallbacks list iterator in production";
+
+  for (int i = 0; i < 400 &&
+       !(adapter_destroyed.load() && peer_destroyed.load());
+       ++i) {
+    std::this_thread::sleep_for(5ms);
+  }
+  EXPECT_TRUE(adapter_destroyed.load()) << "adapter must eventually drain";
+  EXPECT_TRUE(peer_destroyed.load()) << "peer must eventually drain";
+}
+
 }  // namespace
 }  // namespace event
 }  // namespace mcp

--- a/tests/event/test_deferred_delete_ordering.cc
+++ b/tests/event/test_deferred_delete_ordering.cc
@@ -144,6 +144,51 @@ TEST_F(DeferredDeleteOrderingTest, BatchDrainsAfterCallbackReturns) {
   for (auto* f : flags) delete f;
 }
 
+// A Tracer variant that itself queues another Tracer for deferred deletion
+// when it runs. Models the real-world case where a connection's destructor
+// releases sub-objects that also need to defer (filters, session state).
+struct CascadingTracer : public DeferredDeletable {
+  CascadingTracer(std::atomic<bool>& destroyed,
+                  Dispatcher& dispatcher,
+                  std::unique_ptr<DeferredDeletable> child)
+      : destroyed_(destroyed),
+        dispatcher_(dispatcher),
+        child_(std::move(child)) {}
+  ~CascadingTracer() override {
+    if (child_) {
+      dispatcher_.deferredDelete(std::move(child_));
+    }
+    destroyed_ = true;
+  }
+  std::atomic<bool>& destroyed_;
+  Dispatcher& dispatcher_;
+  std::unique_ptr<DeferredDeletable> child_;
+};
+
+// If a destructor re-enters deferredDelete, the dispatcher must drain the
+// newly-queued item on a subsequent pass instead of losing it.
+TEST_F(DeferredDeleteOrderingTest, NestedDeferredDeleteDuringDrainDrainsLater) {
+  std::atomic<bool> outer_destroyed{false};
+  std::atomic<bool> inner_destroyed{false};
+
+  auto inner = std::make_unique<Tracer>(inner_destroyed);
+  auto outer = std::make_unique<CascadingTracer>(outer_destroyed, *dispatcher_,
+                                                 std::move(inner));
+
+  dispatcher_->post(
+      [this, outer_raw = outer.release()]() mutable {
+        dispatcher_->deferredDelete(
+            std::unique_ptr<DeferredDeletable>(outer_raw));
+      });
+
+  for (int i = 0; i < 400 && !inner_destroyed.load(); ++i) {
+    std::this_thread::sleep_for(5ms);
+  }
+  EXPECT_TRUE(outer_destroyed.load()) << "outer must drain first";
+  EXPECT_TRUE(inner_destroyed.load())
+      << "inner queued from outer's destructor must also drain";
+}
+
 }  // namespace
 }  // namespace event
 }  // namespace mcp

--- a/tests/event/test_deferred_delete_ordering.cc
+++ b/tests/event/test_deferred_delete_ordering.cc
@@ -1,0 +1,149 @@
+// Verifies the ordering contract of Dispatcher::deferredDelete(): an object
+// handed to the dispatcher from inside an event callback must NOT be
+// destroyed synchronously — destruction has to wait for the current callback
+// stack to unwind, otherwise close-event handlers would tear down objects
+// while their own callback loops are still iterating.
+//
+// This test exists because the McpConnectionManager close path and the
+// McpServer per-connection teardown both rely on this guarantee. Regressions
+// here would silently reintroduce a use-after-free in the transport layer.
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "mcp/event/event_loop.h"
+#include "mcp/event/libevent_dispatcher.h"
+
+namespace mcp {
+namespace event {
+namespace {
+
+using namespace std::chrono_literals;
+
+class DeferredDeleteOrderingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto factory = createLibeventDispatcherFactory();
+    dispatcher_ = factory->createDispatcher("dd-test");
+    loop_thread_ = std::thread([this]() { dispatcher_->run(RunType::Block); });
+    // Give libevent a moment to actually enter the loop before we start
+    // posting callbacks into it.
+    std::this_thread::sleep_for(20ms);
+  }
+
+  void TearDown() override {
+    if (dispatcher_) {
+      dispatcher_->exit();
+    }
+    if (loop_thread_.joinable()) {
+      loop_thread_.join();
+    }
+    dispatcher_.reset();
+  }
+
+  std::unique_ptr<Dispatcher> dispatcher_;
+  std::thread loop_thread_;
+};
+
+// A tracer object that records whether its destructor has run.
+struct Tracer : public DeferredDeletable {
+  explicit Tracer(std::atomic<bool>& destroyed) : destroyed_(destroyed) {}
+  ~Tracer() override { destroyed_ = true; }
+  std::atomic<bool>& destroyed_;
+};
+
+// When deferredDelete is called from inside a dispatcher callback, the
+// destructor must NOT run before that callback returns. This is the contract
+// that makes it safe to deferredDelete(std::move(active_connection_)) while
+// the connection is still iterating its own callback list.
+TEST_F(DeferredDeleteOrderingTest, DestructionDeferredUntilAfterCallback) {
+  std::atomic<bool> destroyed{false};
+  std::atomic<bool> callback_still_alive_at_delete_point{false};
+  auto tracer = std::make_unique<Tracer>(destroyed);
+
+  std::atomic<bool> callback_done{false};
+
+  dispatcher_->post([&, this]() {
+    dispatcher_->deferredDelete(std::move(tracer));
+    // Immediately after the deferredDelete call, the tracer must still be
+    // alive. If deferredDelete destroyed synchronously, `destroyed` would
+    // already be true at this observation point.
+    callback_still_alive_at_delete_point = !destroyed.load();
+    callback_done = true;
+  });
+
+  // Wait for the post to run.
+  for (int i = 0; i < 200 && !callback_done.load(); ++i) {
+    std::this_thread::sleep_for(5ms);
+  }
+  ASSERT_TRUE(callback_done.load()) << "dispatcher never ran the callback";
+
+  EXPECT_TRUE(callback_still_alive_at_delete_point)
+      << "deferredDelete destroyed the object synchronously inside the "
+         "callback — this would cause a use-after-free for connection close "
+         "handlers";
+
+  // Eventually the dispatcher must drain the deferred-delete queue.
+  for (int i = 0; i < 200 && !destroyed.load(); ++i) {
+    std::this_thread::sleep_for(5ms);
+  }
+  EXPECT_TRUE(destroyed.load())
+      << "deferred delete never drained — object leaked";
+}
+
+// Multiple objects queued in one callback should all be destroyed on the
+// same drain pass, not interleaved with unrelated work.
+TEST_F(DeferredDeleteOrderingTest, BatchDrainsAfterCallbackReturns) {
+  constexpr int kCount = 5;
+  std::atomic<int> destroyed_count{0};
+  std::vector<std::unique_ptr<DeferredDeletable>> tracers;
+  std::vector<std::atomic<bool>*> flags;
+  for (int i = 0; i < kCount; ++i) {
+    auto* flag = new std::atomic<bool>(false);
+    flags.push_back(flag);
+    tracers.emplace_back(std::make_unique<Tracer>(*flag));
+  }
+
+  std::atomic<bool> callback_done{false};
+  int destroyed_inside_callback = -1;
+
+  dispatcher_->post([&, this]() {
+    for (auto& t : tracers) {
+      dispatcher_->deferredDelete(std::move(t));
+    }
+    destroyed_inside_callback = 0;
+    for (auto* f : flags) {
+      if (f->load()) ++destroyed_inside_callback;
+    }
+    callback_done = true;
+  });
+
+  for (int i = 0; i < 200 && !callback_done.load(); ++i) {
+    std::this_thread::sleep_for(5ms);
+  }
+  ASSERT_TRUE(callback_done.load());
+
+  EXPECT_EQ(destroyed_inside_callback, 0)
+      << "no tracer should have been destroyed synchronously";
+
+  for (int i = 0; i < 400 && destroyed_count.load() < kCount; ++i) {
+    destroyed_count = 0;
+    for (auto* f : flags) {
+      if (f->load()) ++destroyed_count;
+    }
+    if (destroyed_count.load() >= kCount) break;
+    std::this_thread::sleep_for(5ms);
+  }
+  EXPECT_EQ(destroyed_count.load(), kCount)
+      << "all queued tracers must eventually drain";
+
+  for (auto* f : flags) delete f;
+}
+
+}  // namespace
+}  // namespace event
+}  // namespace mcp

--- a/tests/event/test_timer_lifetime.cc
+++ b/tests/event/test_timer_lifetime.cc
@@ -362,6 +362,44 @@ TEST_F(TimerLifetimeTest, TimerCleanupOnDestruction) {
   EXPECT_FALSE(callback_executed);
 }
 
+/**
+ * Test: Periodic timer pattern — timer stored as a member, re-armed by its
+ * own callback via enableTimer on the same TimerPtr. This is the pattern
+ * McpServer's background tasks rely on; the previous code created a fresh
+ * TimerPtr on each fire, which both leaked scheduling state and destroyed
+ * the currently-firing timer from inside its own callback.
+ */
+TEST_F(TimerLifetimeTest, PeriodicReArmOnSameTimerFiresRepeatedly) {
+  std::atomic<int> fire_count{0};
+  event::TimerPtr timer;
+
+  auto interval = std::chrono::milliseconds(20);
+
+  // Capture the timer by reference so the callback re-arms the exact same
+  // TimerPtr each tick — the pattern McpServer uses.
+  timer = dispatcher_->createTimer([&timer, &fire_count, interval]() {
+    fire_count++;
+    timer->enableTimer(interval);
+  });
+  timer->enableTimer(interval);
+
+  runDispatcher();
+  std::this_thread::sleep_for(std::chrono::milliseconds(120));
+
+  // Expect at least 4 fires in ~120ms at 20ms cadence. We're loose on the
+  // upper bound because CI scheduling jitter can double this on loaded
+  // runners.
+  EXPECT_GE(fire_count.load(), 4)
+      << "member timer with self-rearm must keep firing";
+
+  // disableTimer must stop the cadence promptly.
+  timer->disableTimer();
+  int count_at_disable = fire_count.load();
+  std::this_thread::sleep_for(std::chrono::milliseconds(80));
+  EXPECT_LE(fire_count.load(), count_at_disable + 1)
+      << "disableTimer must prevent further fires";
+}
+
 }  // namespace
 }  // namespace event
 }  // namespace mcp

--- a/tests/filter/test_http_codec_filter.cc
+++ b/tests/filter/test_http_codec_filter.cc
@@ -548,6 +548,47 @@ TEST_F(HttpCodecFilterRealIoTest, StateMachineIntegration) {
   EXPECT_EQ(headers["url"], "/state-test");
 }
 
+// ---------------------------------------------------------------------------
+// Body-timeout wiring by role
+//
+// Regression guard for the SSE crash: in client mode the codec is expected
+// to disable the body timer (body_timeout == 0) because SSE response bodies
+// are an open-ended stream that may sit idle between server-pushed events.
+// In server mode the 60s body timeout must stay on — request bodies are
+// expected to complete promptly. These tests read back the value actually
+// stored on the state machine so a regression in the is_server_ ternary in
+// http_codec_filter.cc is caught directly.
+// ---------------------------------------------------------------------------
+
+class HttpCodecFilterBodyTimeoutTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto factory = event::createLibeventDispatcherFactory();
+    dispatcher_ = factory->createDispatcher("codec-bt");
+    // Run once so timers can be created (state machine arms from ctor).
+    dispatcher_->run(event::RunType::NonBlock);
+    callbacks_ = std::make_unique<TestRequestCallbacks>();
+  }
+
+  std::unique_ptr<event::Dispatcher> dispatcher_;
+  std::unique_ptr<TestRequestCallbacks> callbacks_;
+};
+
+TEST_F(HttpCodecFilterBodyTimeoutTest, ServerModeKeepsBodyTimeoutBounded) {
+  HttpCodecFilter filter(*callbacks_, *dispatcher_, /*is_server=*/true);
+  EXPECT_EQ(filter.bodyTimeout(), 60000ms)
+      << "server mode must retain a bounded body timeout so request bodies "
+         "that stall don't wedge a connection";
+}
+
+TEST_F(HttpCodecFilterBodyTimeoutTest, ClientModeDisablesBodyTimeout) {
+  HttpCodecFilter filter(*callbacks_, *dispatcher_, /*is_server=*/false);
+  EXPECT_EQ(filter.bodyTimeout(), 0ms)
+      << "client mode must disable the body timer — an SSE response body is "
+         "an open-ended stream and a bounded body timeout would fire during "
+         "normal idle gaps, then crash the state machine on a live stream";
+}
+
 }  // namespace
 }  // namespace filter
 }  // namespace mcp

--- a/tests/filter/test_http_codec_state_machine.cc
+++ b/tests/filter/test_http_codec_state_machine.cc
@@ -273,6 +273,39 @@ TEST_F(HttpCodecStateMachineTest, BodyTimeout) {
   expectState(HttpCodecState::Error);
 }
 
+// A body_timeout of 0 must disable the body timer entirely. Client-mode
+// HTTP streams that carry SSE responses stay open indefinitely with
+// arbitrary gaps between server events; a non-zero body timeout would
+// fire on idle and tear the stream down. HttpCodecFilter's client-mode
+// constructor passes 0 for exactly this reason, and relies on the state
+// machine honoring "0 == disabled".
+TEST_F(HttpCodecStateMachineTest, BodyTimeoutDisabledWhenZero) {
+  bool error_called = false;
+  config_.body_timeout = 0ms;
+  config_.error_callback = [&error_called](const std::string&) {
+    error_called = true;
+  };
+  state_machine_ =
+      std::make_unique<HttpCodecStateMachine>(*dispatcher_, config_);
+
+  state_machine_->handleEvent(HttpCodecEvent::RequestBegin);
+  runFor(10ms);
+
+  state_machine_->setExpectRequestBody(true);
+  state_machine_->handleEvent(HttpCodecEvent::RequestHeadersComplete);
+  runFor(10ms);
+  expectState(HttpCodecState::ReceivingRequestBody);
+
+  // Run well past what the default 200ms body timeout would be. With
+  // body_timeout == 0 the timer must never have been armed, so we stay
+  // in ReceivingRequestBody with no error.
+  runFor(300ms);
+
+  EXPECT_FALSE(error_called)
+      << "body_timeout == 0 must not raise a timeout error";
+  expectState(HttpCodecState::ReceivingRequestBody);
+}
+
 TEST_F(HttpCodecStateMachineTest, IdleTimeout) {
   expectState(HttpCodecState::WaitingForRequest);
 


### PR DESCRIPTION
## Summary

Six independent crash/ordering fixes, split one-per-commit for review. Each addresses a real production crash or hang observed in PR #211's larger bundle; this PR lands the crash fixes cleanly without the SSE-transport / libcurl work, which will follow as separate PRs.

## Commits

1. **Fix `scheduleCallbackCurrentIteration` to defer past caller's stack frame** — the primitive was running the callback synchronously when called on the dispatcher thread, breaking the `deferredDelete` contract. Route on-thread scheduling through a 0ms timer. Adds `test_deferred_delete_ordering` covering the contract.
2. **Defer closed-connection destruction via `Dispatcher::deferredDelete`** — replaces the `shared_ptr<ConnectionPtr>` + `post()` workaround with the correct primitive. Adds a dispatcher-thread assert on entry.
3. **Fix background-task timer lifetime in `McpServer`** — timers were local `unique_ptr`s that dropped at end of scope, so ticks never fired. Hold as members; re-arm via `enableTimer` on the same timer.
4. **Bind server connection callbacks per connection via adapter** — removes the stale `current_connection_` fallback. Each connection gets its own `ConnectionLifecycleCallbacks`, handed to `deferredDelete` alongside the connection on close.
5. **Route `initializeProtocol` state commit back to the dispatcher thread** — worker thread was mutating `server_capabilities_`, `initialized_`, and the protocol state machine off-thread. Now parses on the worker and commits state via `main_dispatcher_->post`.
6. **Disable body timeout for client-mode HTTP codec** — SSE response bodies are open-ended; 60s body timeout was firing and crashing `HttpCodecStateMachine::executeTransition()`. Server mode keeps the bounded timeout.

  ## Test plan

  - [x] `test_deferred_delete_ordering` (new) — 4 cases: synchronous-deferral
        contract, batched drain, nested-during-drain, lifecycle-adapter
        self+peer pattern
  - [x] `test_timer_lifetime` (new) — re-arm-same-TimerPtr contract used by
        McpServer background tasks
  - [x] `test_http_codec_state_machine` — adds `BodyTimeoutDisabledWhenZero`
        proving body_timeout==0 disables the body timer
  - [x] `test_http_codec_filter` — adds `HttpCodecFilterBodyTimeoutTest` ×
        2, confirming client mode wires body_timeout=0 and server mode
        retains 60s
  - [x] `test_mcp_connection_manager` — two new cases
        (`OnCloseRunsCleanlyOnDispatcherThread`,
        `RepeatedEventSequencesOnDispatcherThreadDoNotCrash`) plus the two
        existing `OnConnectionEventPreventsDuplicate*` cases refactored to
        drive through the dispatcher to satisfy the new `isThreadSafe()`
        assert
  - [x] Full `ctest` suite: 118/118 passing
  - [ ] Extended runtime soak against production MCP backends (reviewers to verify)

  And in Out-of-scope, add a line clarifying the remaining integration-level gaps that PR D picks up:

  - McpServer integration tests for ConnectionLifecycleCallbacks real-connection
    close path and background timer lifetime (tracked for PR D — need full
    ApplicationBase bootstrap; adapter/timer contracts already covered at
    primitive level in this PR)
  - McpClient initializeProtocol integration test (same rationale — tracked for PR D)