### PR TITLE
Add SSE server transport for HTTP+SSE filter chain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,7 @@ set(MCP_CORE_SOURCES
     src/filter/http_codec_state_machine.cc
     src/filter/sse_codec_state_machine.cc
     src/filter/http_sse_filter_chain_factory.cc
+    src/filter/sse_session_registry.cc
     src/filter/stdio_filter_chain_factory.cc
     src/filter/json_rpc_protocol_filter.cc
     src/filter/protocol_detection_filter_chain_factory.cc

--- a/include/mcp/filter/http_sse_filter_chain_factory.h
+++ b/include/mcp/filter/http_sse_filter_chain_factory.h
@@ -18,6 +18,7 @@ class McpProtocolCallbacks;
 namespace filter {
 class HttpRoutingFilter;
 class MetricsFilter;
+class SseSessionRegistry;
 }  // namespace filter
 }  // namespace mcp
 
@@ -83,16 +84,11 @@ class HttpSseFilterChainFactory : public network::FilterChainFactory {
                             bool use_sse = true,
                             const std::string& sse_path = "/sse",
                             const std::string& rpc_path = "/mcp",
-                            const std::string& external_url = "")
-      : dispatcher_(dispatcher),
-        message_callbacks_(message_callbacks),
-        is_server_(is_server),
-        http_path_(http_path),
-        http_host_(http_host),
-        use_sse_(use_sse),
-        sse_path_(sse_path),
-        rpc_path_(rpc_path),
-        external_url_(external_url) {}
+                            const std::string& external_url = "");
+
+  // Destructor defined out-of-line so the unique_ptr<SseSessionRegistry>
+  // member can use the incomplete forward-declared type in this header.
+  ~HttpSseFilterChainFactory();
 
   /**
    * Create filter chain for the connection
@@ -188,6 +184,16 @@ class HttpSseFilterChainFactory : public network::FilterChainFactory {
   std::string rpc_path_;      // Server-side JSON-RPC endpoint path (e.g., "/mcp")
   std::string external_url_;  // External URL for absolute SSE callback URLs
   mutable bool enable_metrics_ = true;  // Enable metrics by default
+
+  // SSE session registry — maps session IDs to the connections that are
+  // streaming SSE to each client, so POST /callback/{id} handlers can
+  // route a JSON-RPC response back through the correct stream. Lazily
+  // constructed on the first server-side filter chain creation; stays
+  // null for client-mode factories. Owned here (not a global singleton)
+  // so each McpServer instance has an isolated registry and lifetime is
+  // bounded by the factory, not process lifetime. Mutable because
+  // createFilterChain is const on the base class.
+  mutable std::unique_ptr<SseSessionRegistry> sse_registry_;
 
   // Store filters for lifetime management
   mutable std::vector<network::FilterSharedPtr> filters_;

--- a/include/mcp/filter/http_sse_filter_chain_factory.h
+++ b/include/mcp/filter/http_sse_filter_chain_factory.h
@@ -177,11 +177,11 @@ class HttpSseFilterChainFactory : public network::FilterChainFactory {
   event::Dispatcher& dispatcher_;
   McpProtocolCallbacks& message_callbacks_;
   bool is_server_;
-  std::string http_path_;     // HTTP request path for client mode
-  std::string http_host_;     // HTTP Host header for client mode
-  bool use_sse_;              // True for SSE mode, false for Streamable HTTP
-  std::string sse_path_;      // Server-side SSE endpoint path (e.g., "/sse")
-  std::string rpc_path_;      // Server-side JSON-RPC endpoint path (e.g., "/mcp")
+  std::string http_path_;  // HTTP request path for client mode
+  std::string http_host_;  // HTTP Host header for client mode
+  bool use_sse_;           // True for SSE mode, false for Streamable HTTP
+  std::string sse_path_;   // Server-side SSE endpoint path (e.g., "/sse")
+  std::string rpc_path_;   // Server-side JSON-RPC endpoint path (e.g., "/mcp")
   std::string external_url_;  // External URL for absolute SSE callback URLs
   mutable bool enable_metrics_ = true;  // Enable metrics by default
 

--- a/include/mcp/filter/http_sse_filter_chain_factory.h
+++ b/include/mcp/filter/http_sse_filter_chain_factory.h
@@ -66,19 +66,33 @@ class HttpSseFilterChainFactory : public network::FilterChainFactory {
    * @param http_host HTTP Host header value for client mode
    * @param use_sse True for SSE mode (GET /sse first), false for Streamable
    * HTTP (direct POST)
+   * @param sse_path Server-side SSE endpoint path (e.g., "/sse"). Only
+   *                 meaningful when is_server=true.
+   * @param rpc_path Server-side JSON-RPC endpoint path (e.g., "/mcp"). Only
+   *                 meaningful when is_server=true.
+   * @param external_url Absolute URL the server is reachable at from the
+   *                 client's perspective. Used to build the endpoint-event
+   *                 callback URL advertised on GET /sse. Leave empty to
+   *                 derive the URL from the incoming Host header.
    */
   HttpSseFilterChainFactory(event::Dispatcher& dispatcher,
                             McpProtocolCallbacks& message_callbacks,
                             bool is_server = true,
                             const std::string& http_path = "/rpc",
                             const std::string& http_host = "localhost",
-                            bool use_sse = true)
+                            bool use_sse = true,
+                            const std::string& sse_path = "/sse",
+                            const std::string& rpc_path = "/mcp",
+                            const std::string& external_url = "")
       : dispatcher_(dispatcher),
         message_callbacks_(message_callbacks),
         is_server_(is_server),
         http_path_(http_path),
         http_host_(http_host),
-        use_sse_(use_sse) {}
+        use_sse_(use_sse),
+        sse_path_(sse_path),
+        rpc_path_(rpc_path),
+        external_url_(external_url) {}
 
   /**
    * Create filter chain for the connection
@@ -167,9 +181,12 @@ class HttpSseFilterChainFactory : public network::FilterChainFactory {
   event::Dispatcher& dispatcher_;
   McpProtocolCallbacks& message_callbacks_;
   bool is_server_;
-  std::string http_path_;  // HTTP request path for client mode
-  std::string http_host_;  // HTTP Host header for client mode
-  bool use_sse_;           // True for SSE mode, false for Streamable HTTP
+  std::string http_path_;     // HTTP request path for client mode
+  std::string http_host_;     // HTTP Host header for client mode
+  bool use_sse_;              // True for SSE mode, false for Streamable HTTP
+  std::string sse_path_;      // Server-side SSE endpoint path (e.g., "/sse")
+  std::string rpc_path_;      // Server-side JSON-RPC endpoint path (e.g., "/mcp")
+  std::string external_url_;  // External URL for absolute SSE callback URLs
   mutable bool enable_metrics_ = true;  // Enable metrics by default
 
   // Store filters for lifetime management

--- a/include/mcp/filter/sse_session_registry.h
+++ b/include/mcp/filter/sse_session_registry.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include "mcp/event/event_loop.h"
+#include "mcp/network/connection.h"
+
+namespace mcp {
+namespace filter {
+
+/**
+ * SseSessionRegistry — dispatcher-owned map of SSE session IDs to the
+ * network::Connection* streaming SSE back to each client.
+ *
+ * MCP SSE transport splits a request/response pair across two TCP
+ * connections on the server:
+ *   1. A long-lived GET /sse stream the client leaves open for
+ *      server-sent events. The server registers this connection under a
+ *      fresh session ID and announces a POST callback URL containing
+ *      that ID in the "endpoint" event.
+ *   2. Short POST /callback/{session_id} connections — one per outbound
+ *      JSON-RPC request. The server returns 202 Accepted immediately and
+ *      routes the JSON-RPC response through the SSE connection registered
+ *      under the matching session ID.
+ *
+ * The registry is what lets the POST handler find the SSE connection it
+ * must route the response through. It is owned by the HTTP+SSE filter
+ * chain factory (one per McpServer), not a process-wide singleton:
+ *   - Independent McpServer instances in the same process do not share
+ *     session IDs or leak into each other.
+ *   - Lifetime is bounded by the factory, which is owned by McpServer —
+ *     no global state to reason about at shutdown.
+ *
+ * Threading model:
+ *   - The MCP server runs on a single dispatcher thread. All filter
+ *     callbacks (onHeaders, onWrite, filter destructor) fire on that
+ *     thread, so registry mutations are naturally single-threaded.
+ *   - Every public method asserts isThreadSafe() so a future move to a
+ *     worker-thread model fails loudly instead of silently corrupting
+ *     the map.
+ */
+class SseSessionRegistry {
+ public:
+  explicit SseSessionRegistry(event::Dispatcher& dispatcher);
+
+  // Record an SSE stream connection and hand back a stable session ID.
+  // Caller must call removeSession() when the stream closes — the SSE
+  // filter's destructor does this.
+  std::string registerSession(network::Connection* connection);
+
+  // Drop a session. Safe to call with an unknown ID (no-op).
+  void removeSession(const std::string& session_id);
+
+  // Write a JSON-RPC response through the SSE stream registered under
+  // session_id. Returns true if the session existed and the write was
+  // handed to the connection (the SSE codec filter further down the
+  // write chain frames the bytes into a `data: ...\n\n` SSE event).
+  // Returns false if the session has gone away (e.g. client already
+  // disconnected); the caller should drop the response rather than
+  // pretending it was delivered.
+  bool sendResponse(const std::string& session_id,
+                    const std::string& json_data);
+
+  // Test / introspection: current session count. Asserts dispatcher
+  // thread to match the rest of the API.
+  size_t sessionCount() const;
+
+  // Test / introspection: whether a given ID is currently registered.
+  bool hasSession(const std::string& session_id) const;
+
+ private:
+  event::Dispatcher& dispatcher_;
+  std::map<std::string, network::Connection*> sessions_;
+  uint64_t next_id_{1};
+};
+
+}  // namespace filter
+}  // namespace mcp

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -88,8 +88,15 @@ struct McpServerConfig : public application::ApplicationBase::Config {
 
   // HTTP/SSE specific configuration
   std::string http_rpc_path = "/rpc";        // Path for JSON-RPC over HTTP
-  std::string http_sse_path = "/events";     // Path for SSE event stream
+  std::string http_sse_path = "/sse";        // Path for SSE event stream
   std::string http_health_path = "/health";  // Path for health check endpoint
+  // Absolute URL the server is reachable at from the client's perspective
+  // (scheme + host + port + optional path prefix). Used to build the
+  // endpoint-event callback URL advertised on GET /sse. Leave empty to
+  // have the server derive a URL from the incoming Host header; set
+  // explicitly when the server sits behind a reverse proxy that rewrites
+  // scheme or path so clients don't try to POST back to an internal URL.
+  std::string external_url;
 
   // Session management
   size_t max_sessions = 100;

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -50,8 +50,12 @@
 
 #include "mcp/filter/http_sse_filter_chain_factory.h"
 
+#include <cassert>
+#include <cstdint>
 #include <ctime>
+#include <map>
 #include <sstream>
+#include <utility>
 
 #include "mcp/filter/http_codec_filter.h"
 #include "mcp/filter/http_routing_filter.h"
@@ -65,6 +69,99 @@
 
 namespace mcp {
 namespace filter {
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SseSessionRegistry — dispatcher-owned map of SSE session IDs to the
+// network::Connection* that is streaming SSE back to each client.
+//
+// MCP SSE transport splits the request/response pair across two TCP
+// connections:
+//   1. A long-lived GET /sse stream that the client leaves open for
+//      server-sent events. The server registers this connection under a
+//      fresh session ID and announces a POST callback URL containing
+//      that ID in the "endpoint" event.
+//   2. Short POST /callback/{session_id} connections — one per outbound
+//      JSON-RPC request from the client. The server returns 202 Accepted
+//      immediately and then routes the actual JSON-RPC response through
+//      the SSE connection registered under that session ID.
+//
+// The registry is what lets the POST handler find the SSE connection it
+// has to route the response through. It lives on the filter chain
+// factory (one per McpServer), not as a process-wide singleton, so:
+//   - Independent McpServer instances in the same process do not share
+//     session IDs or leak into each other.
+//   - Registry lifetime is bounded by the factory, which is owned by
+//     McpServer — no global state to reason about at shutdown.
+//
+// Threading model:
+//   - The MCP server runs on a single dispatcher thread. All filter
+//     callbacks (onHeaders, onWrite, filter destructor) fire on that
+//     thread, so registry mutations are naturally single-threaded.
+//   - Every public method asserts isThreadSafe() so a future move to a
+//     worker-thread model fails loudly instead of silently corrupting
+//     the map.
+// ═══════════════════════════════════════════════════════════════════════════
+class SseSessionRegistry {
+ public:
+  explicit SseSessionRegistry(event::Dispatcher& dispatcher)
+      : dispatcher_(dispatcher) {}
+
+  // Record an SSE stream connection and hand back a stable session ID.
+  // Caller is responsible for calling removeSession() when the stream
+  // closes (filter destructor does this).
+  std::string registerSession(network::Connection* connection) {
+    assert(dispatcher_.isThreadSafe() &&
+           "SseSessionRegistry::registerSession off-dispatcher-thread");
+    std::string session_id = "client_" + std::to_string(next_id_++);
+    sessions_[session_id] = connection;
+    GOPHER_LOG_INFO("SSE session registered: {} (total={})", session_id,
+                    sessions_.size());
+    return session_id;
+  }
+
+  // Drop a session. Safe to call with an unknown ID (no-op). Typically
+  // invoked from the SSE filter's destructor when the stream connection
+  // closes.
+  void removeSession(const std::string& session_id) {
+    assert(dispatcher_.isThreadSafe() &&
+           "SseSessionRegistry::removeSession off-dispatcher-thread");
+    if (sessions_.erase(session_id) > 0) {
+      GOPHER_LOG_INFO("SSE session removed: {} (total={})", session_id,
+                      sessions_.size());
+    }
+  }
+
+  // Write a JSON-RPC response through the SSE stream registered under
+  // session_id. Returns true if the session existed and the write was
+  // handed to the connection (the actual wire bytes are framed into a
+  // `data: ...\n\n` SSE event by the SSE codec filter further down that
+  // connection's write chain). Returns false if the session has gone
+  // away (e.g. client already disconnected while we were handling the
+  // POST), in which case the caller should drop the response on the
+  // floor rather than pretending it was delivered.
+  bool sendResponse(const std::string& session_id,
+                    const std::string& json_data) {
+    assert(dispatcher_.isThreadSafe() &&
+           "SseSessionRegistry::sendResponse off-dispatcher-thread");
+    auto it = sessions_.find(session_id);
+    if (it == sessions_.end()) {
+      GOPHER_LOG_WARN("SSE session not found for response routing: {}",
+                      session_id);
+      return false;
+    }
+    OwnedBuffer buffer;
+    buffer.add(json_data.c_str(), json_data.length());
+    it->second->write(buffer, /*end_stream=*/false);
+    GOPHER_LOG_DEBUG("SSE response routed to session {} ({} bytes)",
+                     session_id, json_data.size());
+    return true;
+  }
+
+ private:
+  event::Dispatcher& dispatcher_;
+  std::map<std::string, network::Connection*> sessions_;
+  uint64_t next_id_{1};
+};
 
 // Forward declaration
 class HttpSseJsonRpcProtocolFilter;
@@ -140,13 +237,21 @@ class HttpSseJsonRpcProtocolFilter
       const std::string& http_path = "/rpc",
       const std::string& http_host = "localhost",
       bool use_sse = true,
-      const HttpRouteRegistrationCallback& route_callback = nullptr)
+      const HttpRouteRegistrationCallback& route_callback = nullptr,
+      const std::string& configured_sse_path = "/sse",
+      const std::string& configured_rpc_path = "/mcp",
+      const std::string& configured_external_url = "",
+      SseSessionRegistry* sse_registry = nullptr)
       : dispatcher_(dispatcher),
         mcp_callbacks_(mcp_callbacks),
         is_server_(is_server),
         http_path_(http_path),
         http_host_(http_host),
         use_sse_(use_sse),
+        configured_sse_path_(configured_sse_path),
+        configured_rpc_path_(configured_rpc_path),
+        configured_external_url_(configured_external_url),
+        sse_registry_(sse_registry),
         route_registration_callback_(route_callback) {
     // Following production pattern: all operations for this filter
     // happen in the single dispatcher thread
@@ -188,7 +293,16 @@ class HttpSseJsonRpcProtocolFilter
         std::make_shared<JsonRpcProtocolFilter>(*this, dispatcher_, is_server_);
   }
 
-  ~HttpSseJsonRpcProtocolFilter() = default;
+  ~HttpSseJsonRpcProtocolFilter() {
+    // SSE stream connection is closing — drop this session from the
+    // registry so a POST /callback/{id} that arrives between close and
+    // destructor doesn't route a response into a dead connection. Runs
+    // on the dispatcher thread (filters destruct on-thread by contract).
+    if (sse_registry_ && !sse_session_id_.empty()) {
+      sse_registry_->removeSession(sse_session_id_);
+      sse_session_id_.clear();
+    }
+  }
 
   // ===== Network Filter Interface =====
 
@@ -295,6 +409,39 @@ class HttpSseJsonRpcProtocolFilter
    * recursion!
    */
   network::FilterStatus onWrite(Buffer& data, bool end_stream) override {
+    // SSE handshake bypass: we're inside a connection().write() call
+    // made from our own onHeaders (writing "HTTP/1.1 200 OK ... event:
+    // endpoint" for GET /sse, or "HTTP/1.1 202 Accepted" for POST
+    // /callback). The bytes are already fully-formed HTTP — skip all
+    // downstream JSON-RPC / HTTP-codec framing.
+    if (sse_writing_handshake_) {
+      return network::FilterStatus::Continue;
+    }
+
+    // SSE callback routing: the JSON-RPC filter is emitting the response
+    // for a POST /callback/{id}. We already sent 202 Accepted on that
+    // POST connection, so we must NOT let these bytes continue down the
+    // write chain to be framed as HTTP and written back to the POST
+    // connection. Instead, pull the JSON body out and hand it to the
+    // registry, which writes it through the matching SSE stream.
+    if (is_server_ && !sse_callback_session_id_.empty() && data.length() > 0) {
+      const size_t len = data.length();
+      std::string json_data(static_cast<const char*>(data.linearize(len)), len);
+      data.drain(len);
+
+      if (sse_registry_) {
+        sse_registry_->sendResponse(sse_callback_session_id_, json_data);
+      } else {
+        GOPHER_LOG_WARN(
+            "SSE callback response dropped: no registry available (session={})",
+            sse_callback_session_id_);
+      }
+
+      // Stop iteration so ConnectionImpl doesn't flush an empty buffer
+      // as HTTP bytes on the POST connection.
+      return network::FilterStatus::StopIteration;
+    }
+
     GOPHER_LOG_DEBUG(
         "HttpSseJsonRpcProtocolFilter: onWrite called, data_len={}, "
         "is_server={}, is_sse_mode={}, waiting_for_endpoint={}, "
@@ -507,20 +654,131 @@ class HttpSseJsonRpcProtocolFilter
 
     // Determine transport mode based on headers
     if (is_server_) {
-      // Server: check Accept header for SSE - but DON'T enable SSE mode yet!
-      // The Accept header just indicates the client SUPPORTS SSE, not that we
-      // should use it. For JSON-RPC request/response (like initialize), we
-      // should use normal HTTP with Content-Length.
-      // SSE mode should only be enabled explicitly when the server wants to
-      // stream notifications. For now, always use normal HTTP for responses.
+      // Pull :method and :path out of the pseudo-headers so we can branch
+      // on the two SSE transport endpoints: GET {sse_path} (open stream)
+      // and POST /callback/{session_id} (route response via stream).
+      std::string method = "GET";
+      auto method_it = headers.find(":method");
+      if (method_it != headers.end()) {
+        method = method_it->second;
+      }
+
+      std::string path = "/";
+      auto path_it = headers.find(":path");
+      if (path_it != headers.end()) {
+        path = path_it->second;
+      } else {
+        // Some codecs surface the request target as "url" rather than the
+        // HTTP/2-style :path pseudo-header. Accept either.
+        auto url_it = headers.find("url");
+        if (url_it != headers.end()) {
+          path = url_it->second;
+        }
+      }
+      // Trim query string before matching — the SSE transport doesn't
+      // use query params on either endpoint and we want /sse?foo=bar to
+      // still open the stream.
+      size_t qpos = path.find('?');
+      if (qpos != std::string::npos) {
+        path = path.substr(0, qpos);
+      }
+
+      // ── GET {configured_sse_path_} → open an SSE stream.
+      if (method == "GET" && path == configured_sse_path_ && sse_registry_ &&
+          write_callbacks_) {
+        client_accepts_sse_ = true;
+        sse_session_id_ =
+            sse_registry_->registerSession(&write_callbacks_->connection());
+
+        // Build the callback URL the client will POST future requests
+        // to. If an external URL is configured (reverse-proxy case) we
+        // announce an absolute URL so the client doesn't try to guess.
+        // Otherwise emit a relative path — it resolves relative to the
+        // SSE URL on the client side and keeps us agnostic to scheme or
+        // host.
+        std::string callback_url;
+        if (!configured_external_url_.empty()) {
+          std::string base = configured_external_url_;
+          if (!base.empty() && base.back() == '/') {
+            base.pop_back();
+          }
+          callback_url = base + "/callback/" + sse_session_id_;
+        } else {
+          callback_url = "callback/" + sse_session_id_;
+        }
+
+        // Write the SSE response prelude + endpoint event straight onto
+        // the wire. We set sse_writing_handshake_ so our own onWrite
+        // passes these bytes through untouched — otherwise the write
+        // filter chain would try to re-frame the raw HTTP bytes as an
+        // SSE event and corrupt the stream.
+        std::ostringstream sse_response;
+        sse_response << "HTTP/1.1 200 OK\r\n";
+        sse_response << "Content-Type: text/event-stream\r\n";
+        sse_response << "Cache-Control: no-cache\r\n";
+        sse_response << "Access-Control-Allow-Origin: *\r\n";
+        sse_response << "\r\n";
+        sse_response << "event: endpoint\n";
+        sse_response << "data: " << callback_url << "\n\n";
+
+        const std::string response_str = sse_response.str();
+        OwnedBuffer response_buffer;
+        response_buffer.add(response_str.c_str(), response_str.length());
+
+        sse_writing_handshake_ = true;
+        write_callbacks_->connection().write(response_buffer, false);
+        sse_writing_handshake_ = false;
+
+        sse_server_mode_ = true;
+        is_sse_mode_ = true;
+        sse_headers_written_ = true;
+
+        GOPHER_LOG_INFO("SSE stream opened: session={} callback_url={}",
+                        sse_session_id_, callback_url);
+        return;
+      }
+
+      // ── POST /callback/{session_id} → route the JSON-RPC body
+      // through the SSE stream registered under {session_id}. We send
+      // 202 Accepted on this POST connection right away and let the
+      // body keep flowing into the JSON-RPC filter normally; onWrite
+      // then intercepts the response before it gets written back to
+      // this POST connection and redirects it to the SSE stream.
+      const std::string callback_prefix = "/callback/";
+      if (method == "POST" && path.compare(0, callback_prefix.size(),
+                                           callback_prefix) == 0) {
+        sse_callback_session_id_ = path.substr(callback_prefix.size());
+        GOPHER_LOG_DEBUG("SSE callback POST: session={}",
+                         sse_callback_session_id_);
+
+        if (write_callbacks_) {
+          const std::string http_202 =
+              "HTTP/1.1 202 Accepted\r\n"
+              "Content-Length: 0\r\n"
+              "Access-Control-Allow-Origin: *\r\n"
+              "\r\n";
+          OwnedBuffer resp_buf;
+          resp_buf.add(http_202.c_str(), http_202.length());
+          sse_writing_handshake_ = true;
+          write_callbacks_->connection().write(resp_buf, false);
+          sse_writing_handshake_ = false;
+        }
+        // Keep is_sse_mode_ off on this connection — the body is plain
+        // JSON-RPC, not an SSE stream. Response routing happens in
+        // onWrite via sse_callback_session_id_.
+        is_sse_mode_ = false;
+        return;
+      }
+
+      // Non-SSE-transport request (POST /mcp Streamable HTTP, /health,
+      // /info, etc.). Preserve the existing behavior: check Accept for
+      // SSE capability but keep plain HTTP mode for request/response.
       auto accept = headers.find("accept");
       if (accept != headers.end() &&
           accept->second.find("text/event-stream") != std::string::npos) {
-        client_accepts_sse_ = true;  // Track that client supports SSE
-        // But don't set is_sse_mode_ = true here - that would break JSON-RPC
+        client_accepts_sse_ = true;
         GOPHER_LOG_DEBUG("HttpSseJsonRpcProtocolFilter: client accepts SSE");
       }
-      // Always use normal HTTP mode for request/response pattern
       is_sse_mode_ = false;
     } else {
       // Client: check Content-Type for SSE
@@ -537,6 +795,13 @@ class HttpSseJsonRpcProtocolFilter
   }
 
   void onBody(const std::string& data, bool end_stream) override {
+    // The long-lived GET /sse request has no request body — but if the
+    // codec surfaces any trailing bytes we don't want to push them down
+    // into the JSON-RPC parser. Ignore bodies on the SSE stream
+    // connection entirely.
+    if (is_server_ && sse_server_mode_) {
+      return;
+    }
     // Server receives JSON-RPC in request body regardless of SSE mode
     // SSE mode only affects the response format
     if (is_server_) {
@@ -912,6 +1177,30 @@ class HttpSseJsonRpcProtocolFilter
   std::string http_host_{"localhost"};  // Default HTTP host for requests
   bool use_sse_{true};  // True for SSE mode, false for Streamable HTTP
 
+  // SSE server transport (only meaningful when is_server_ == true).
+  std::string configured_sse_path_{"/sse"};
+  std::string configured_rpc_path_{"/mcp"};
+  std::string configured_external_url_;
+  // Registry of live SSE session IDs → their stream connections. Shared
+  // with sibling filter instances on the same factory; null in client
+  // mode and in server mode when the factory wasn't built with SSE
+  // server transport (back-compat default constructors).
+  SseSessionRegistry* sse_registry_{nullptr};
+  // This connection serves the long-lived GET /sse stream.
+  bool sse_server_mode_{false};
+  // Pass-through guard: true while we're inside onHeaders writing raw
+  // HTTP bytes (handshake or 202 Accepted) via connection().write(), so
+  // our own onWrite doesn't try to re-frame those bytes.
+  bool sse_writing_handshake_{false};
+  // Session ID this connection's SSE stream is registered under.
+  // Populated when we handle GET /sse, cleared in the destructor.
+  std::string sse_session_id_;
+  // Session ID parsed from an incoming POST /callback/{id}. Non-empty
+  // means onWrite should redirect the response through the SSE stream
+  // registered under this ID instead of writing back to the POST
+  // connection.
+  std::string sse_callback_session_id_;
+
   // SSE endpoint negotiation (client mode only)
   bool waiting_for_sse_endpoint_{false};  // Waiting for "endpoint" SSE event
   std::vector<OwnedBuffer>
@@ -973,6 +1262,30 @@ void HttpSseFilterChainFactory::sendHttpResponse(
 
 // ===== Factory Implementation =====
 
+HttpSseFilterChainFactory::HttpSseFilterChainFactory(
+    event::Dispatcher& dispatcher,
+    McpProtocolCallbacks& message_callbacks,
+    bool is_server,
+    const std::string& http_path,
+    const std::string& http_host,
+    bool use_sse,
+    const std::string& sse_path,
+    const std::string& rpc_path,
+    const std::string& external_url)
+    : dispatcher_(dispatcher),
+      message_callbacks_(message_callbacks),
+      is_server_(is_server),
+      http_path_(http_path),
+      http_host_(http_host),
+      use_sse_(use_sse),
+      sse_path_(sse_path),
+      rpc_path_(rpc_path),
+      external_url_(external_url) {}
+
+// Out-of-line destructor so the unique_ptr<SseSessionRegistry> member
+// can see the complete type from this translation unit.
+HttpSseFilterChainFactory::~HttpSseFilterChainFactory() = default;
+
 bool HttpSseFilterChainFactory::createFilterChain(
     network::FilterManager& filter_manager) const {
   // Following production pattern: create filters in order
@@ -1025,12 +1338,22 @@ bool HttpSseFilterChainFactory::createFilterChain(
   // Routing is now integrated into the combined filter
   // No separate routing filter needed
 
+  // Lazily construct the SSE session registry on the first server-side
+  // filter chain creation. Client-mode factories never touch it, and
+  // back-compat server-mode factories that don't use the SSE transport
+  // still carry a registry — it just sits empty because registerSession
+  // is only called from GET {configured_sse_path_}.
+  if (is_server_ && !sse_registry_) {
+    sse_registry_.reset(new SseSessionRegistry(dispatcher_));
+  }
+
   // Create the combined protocol filter
   // Pass the route registration callback so custom HTTP routes can be
   // registered
   auto combined_filter = std::make_shared<HttpSseJsonRpcProtocolFilter>(
       dispatcher_, message_callbacks_, is_server_, http_path_, http_host_,
-      use_sse_, route_registration_callback_);
+      use_sse_, route_registration_callback_, sse_path_, rpc_path_,
+      external_url_, sse_registry_.get());
 
   // Add as both read and write filter
   filter_manager.addReadFilter(combined_filter);

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -152,8 +152,8 @@ class SseSessionRegistry {
     OwnedBuffer buffer;
     buffer.add(json_data.c_str(), json_data.length());
     it->second->write(buffer, /*end_stream=*/false);
-    GOPHER_LOG_DEBUG("SSE response routed to session {} ({} bytes)",
-                     session_id, json_data.size());
+    GOPHER_LOG_DEBUG("SSE response routed to session {} ({} bytes)", session_id,
+                     json_data.size());
     return true;
   }
 

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -62,6 +62,7 @@
 #include "mcp/filter/json_rpc_protocol_filter.h"
 #include "mcp/filter/metrics_filter.h"
 #include "mcp/filter/sse_codec_filter.h"
+#include "mcp/filter/sse_session_registry.h"
 #include "mcp/json/json_serialization.h"
 #include "mcp/logging/log_macros.h"
 #include "mcp/mcp_connection_manager.h"
@@ -70,98 +71,9 @@
 namespace mcp {
 namespace filter {
 
-// ═══════════════════════════════════════════════════════════════════════════
-// SseSessionRegistry — dispatcher-owned map of SSE session IDs to the
-// network::Connection* that is streaming SSE back to each client.
-//
-// MCP SSE transport splits the request/response pair across two TCP
-// connections:
-//   1. A long-lived GET /sse stream that the client leaves open for
-//      server-sent events. The server registers this connection under a
-//      fresh session ID and announces a POST callback URL containing
-//      that ID in the "endpoint" event.
-//   2. Short POST /callback/{session_id} connections — one per outbound
-//      JSON-RPC request from the client. The server returns 202 Accepted
-//      immediately and then routes the actual JSON-RPC response through
-//      the SSE connection registered under that session ID.
-//
-// The registry is what lets the POST handler find the SSE connection it
-// has to route the response through. It lives on the filter chain
-// factory (one per McpServer), not as a process-wide singleton, so:
-//   - Independent McpServer instances in the same process do not share
-//     session IDs or leak into each other.
-//   - Registry lifetime is bounded by the factory, which is owned by
-//     McpServer — no global state to reason about at shutdown.
-//
-// Threading model:
-//   - The MCP server runs on a single dispatcher thread. All filter
-//     callbacks (onHeaders, onWrite, filter destructor) fire on that
-//     thread, so registry mutations are naturally single-threaded.
-//   - Every public method asserts isThreadSafe() so a future move to a
-//     worker-thread model fails loudly instead of silently corrupting
-//     the map.
-// ═══════════════════════════════════════════════════════════════════════════
-class SseSessionRegistry {
- public:
-  explicit SseSessionRegistry(event::Dispatcher& dispatcher)
-      : dispatcher_(dispatcher) {}
-
-  // Record an SSE stream connection and hand back a stable session ID.
-  // Caller is responsible for calling removeSession() when the stream
-  // closes (filter destructor does this).
-  std::string registerSession(network::Connection* connection) {
-    assert(dispatcher_.isThreadSafe() &&
-           "SseSessionRegistry::registerSession off-dispatcher-thread");
-    std::string session_id = "client_" + std::to_string(next_id_++);
-    sessions_[session_id] = connection;
-    GOPHER_LOG_INFO("SSE session registered: {} (total={})", session_id,
-                    sessions_.size());
-    return session_id;
-  }
-
-  // Drop a session. Safe to call with an unknown ID (no-op). Typically
-  // invoked from the SSE filter's destructor when the stream connection
-  // closes.
-  void removeSession(const std::string& session_id) {
-    assert(dispatcher_.isThreadSafe() &&
-           "SseSessionRegistry::removeSession off-dispatcher-thread");
-    if (sessions_.erase(session_id) > 0) {
-      GOPHER_LOG_INFO("SSE session removed: {} (total={})", session_id,
-                      sessions_.size());
-    }
-  }
-
-  // Write a JSON-RPC response through the SSE stream registered under
-  // session_id. Returns true if the session existed and the write was
-  // handed to the connection (the actual wire bytes are framed into a
-  // `data: ...\n\n` SSE event by the SSE codec filter further down that
-  // connection's write chain). Returns false if the session has gone
-  // away (e.g. client already disconnected while we were handling the
-  // POST), in which case the caller should drop the response on the
-  // floor rather than pretending it was delivered.
-  bool sendResponse(const std::string& session_id,
-                    const std::string& json_data) {
-    assert(dispatcher_.isThreadSafe() &&
-           "SseSessionRegistry::sendResponse off-dispatcher-thread");
-    auto it = sessions_.find(session_id);
-    if (it == sessions_.end()) {
-      GOPHER_LOG_WARN("SSE session not found for response routing: {}",
-                      session_id);
-      return false;
-    }
-    OwnedBuffer buffer;
-    buffer.add(json_data.c_str(), json_data.length());
-    it->second->write(buffer, /*end_stream=*/false);
-    GOPHER_LOG_DEBUG("SSE response routed to session {} ({} bytes)", session_id,
-                     json_data.size());
-    return true;
-  }
-
- private:
-  event::Dispatcher& dispatcher_;
-  std::map<std::string, network::Connection*> sessions_;
-  uint64_t next_id_{1};
-};
+// SseSessionRegistry is defined in mcp/filter/sse_session_registry.h so
+// unit tests can exercise it directly without going through the full
+// filter chain.
 
 // Forward declaration
 class HttpSseJsonRpcProtocolFilter;

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -738,16 +738,23 @@ class HttpSseJsonRpcProtocolFilter
         return;
       }
 
-      // ── POST /callback/{session_id} → route the JSON-RPC body
+      // ── POST .../callback/{session_id} → route the JSON-RPC body
       // through the SSE stream registered under {session_id}. We send
       // 202 Accepted on this POST connection right away and let the
       // body keep flowing into the JSON-RPC filter normally; onWrite
       // then intercepts the response before it gets written back to
       // this POST connection and redirects it to the SSE stream.
+      //
+      // Use rfind to accept a path prefix so deployments behind a
+      // reverse proxy still match. If external_url announces a
+      // callback at /v1/mcp/gateways/xyz/callback/client_1 and the
+      // proxy passes that full path through, we still want to strip
+      // everything up to and including /callback/ and take the
+      // session ID from the tail.
       const std::string callback_prefix = "/callback/";
-      if (method == "POST" && path.compare(0, callback_prefix.size(),
-                                           callback_prefix) == 0) {
-        sse_callback_session_id_ = path.substr(callback_prefix.size());
+      const auto cb_pos = path.rfind(callback_prefix);
+      if (method == "POST" && cb_pos != std::string::npos) {
+        sse_callback_session_id_ = path.substr(cb_pos + callback_prefix.size());
         GOPHER_LOG_DEBUG("SSE callback POST: session={}",
                          sse_callback_session_id_);
 

--- a/src/filter/sse_session_registry.cc
+++ b/src/filter/sse_session_registry.cc
@@ -1,0 +1,65 @@
+#include "mcp/filter/sse_session_registry.h"
+
+#include <cassert>
+
+#include "mcp/buffer.h"
+#include "mcp/logging/log_macros.h"
+
+namespace mcp {
+namespace filter {
+
+SseSessionRegistry::SseSessionRegistry(event::Dispatcher& dispatcher)
+    : dispatcher_(dispatcher) {}
+
+std::string SseSessionRegistry::registerSession(
+    network::Connection* connection) {
+  assert(dispatcher_.isThreadSafe() &&
+         "SseSessionRegistry::registerSession off-dispatcher-thread");
+  std::string session_id = "client_" + std::to_string(next_id_++);
+  sessions_[session_id] = connection;
+  GOPHER_LOG_INFO("SSE session registered: {} (total={})", session_id,
+                  sessions_.size());
+  return session_id;
+}
+
+void SseSessionRegistry::removeSession(const std::string& session_id) {
+  assert(dispatcher_.isThreadSafe() &&
+         "SseSessionRegistry::removeSession off-dispatcher-thread");
+  if (sessions_.erase(session_id) > 0) {
+    GOPHER_LOG_INFO("SSE session removed: {} (total={})", session_id,
+                    sessions_.size());
+  }
+}
+
+bool SseSessionRegistry::sendResponse(const std::string& session_id,
+                                      const std::string& json_data) {
+  assert(dispatcher_.isThreadSafe() &&
+         "SseSessionRegistry::sendResponse off-dispatcher-thread");
+  auto it = sessions_.find(session_id);
+  if (it == sessions_.end()) {
+    GOPHER_LOG_WARN("SSE session not found for response routing: {}",
+                    session_id);
+    return false;
+  }
+  OwnedBuffer buffer;
+  buffer.add(json_data.c_str(), json_data.length());
+  it->second->write(buffer, /*end_stream=*/false);
+  GOPHER_LOG_DEBUG("SSE response routed to session {} ({} bytes)", session_id,
+                   json_data.size());
+  return true;
+}
+
+size_t SseSessionRegistry::sessionCount() const {
+  assert(dispatcher_.isThreadSafe() &&
+         "SseSessionRegistry::sessionCount off-dispatcher-thread");
+  return sessions_.size();
+}
+
+bool SseSessionRegistry::hasSession(const std::string& session_id) const {
+  assert(dispatcher_.isThreadSafe() &&
+         "SseSessionRegistry::hasSession off-dispatcher-thread");
+  return sessions_.find(session_id) != sessions_.end();
+}
+
+}  // namespace filter
+}  // namespace mcp

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -217,9 +217,23 @@ void McpServer::performListen() {
         // backward compatibility
         GOPHER_LOG_INFO("Using default HTTP/SSE filter chain factory");
 
+        // Pass the configured endpoint paths (and optional external_url
+        // for reverse-proxy deployments) through to the filter chain so
+        // the SSE server transport advertises callbacks under whatever
+        // paths the operator picked in McpServerConfig. The trailing
+        // defaults of the ctor cover use_sse and the client-mode
+        // http_path/http_host — those are unused in server mode but
+        // still positional in the signature.
         auto http_sse_factory =
             std::make_shared<filter::HttpSseFilterChainFactory>(
-                *main_dispatcher_, *protocol_callbacks_);
+                *main_dispatcher_, *protocol_callbacks_,
+                /*is_server=*/true,
+                /*http_path=*/config_.http_rpc_path,
+                /*http_host=*/"localhost",
+                /*use_sse=*/true,
+                /*sse_path=*/config_.http_sse_path,
+                /*rpc_path=*/config_.http_rpc_path,
+                /*external_url=*/config_.external_url);
 
         // Add filter factories from config (e.g., auth filters)
         // This follows the existing FilterFactoryCb pattern

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -837,8 +837,8 @@ void McpServer::onConnectionLifecycleEvent(network::Connection* connection,
   // close-triggered callback would be UB. Shutdown already sets this flag
   // before the destructor starts tearing members down.
   if (server_running_) {
-    for (auto it = active_connections_.begin();
-         it != active_connections_.end(); ++it) {
+    for (auto it = active_connections_.begin(); it != active_connections_.end();
+         ++it) {
       if (it->get() == connection) {
         main_dispatcher_->deferredDelete(std::move(*it));
         active_connections_.erase(it);
@@ -1199,25 +1199,27 @@ void McpServer::startBackgroundTasks() {
 
   const auto cleanup_interval = std::chrono::seconds(30);
 
-  session_cleanup_timer_ = main_dispatcher_->createTimer([this, cleanup_interval]() {
-    if (!background_threads_running_) {
-      return;
-    }
-    session_manager_->cleanupExpiredSessions();
-    // Re-arm for the next tick. The timer is a member, so firing is safe.
-    session_cleanup_timer_->enableTimer(cleanup_interval);
-  });
+  session_cleanup_timer_ =
+      main_dispatcher_->createTimer([this, cleanup_interval]() {
+        if (!background_threads_running_) {
+          return;
+        }
+        session_manager_->cleanupExpiredSessions();
+        // Re-arm for the next tick. The timer is a member, so firing is safe.
+        session_cleanup_timer_->enableTimer(cleanup_interval);
+      });
   session_cleanup_timer_->enableTimer(cleanup_interval);
 
   const auto update_interval = config_.resource_update_debounce;
 
-  resource_update_timer_ = main_dispatcher_->createTimer([this, update_interval]() {
-    if (!background_threads_running_) {
-      return;
-    }
-    // Resource-update dispatch hooks in here when enabled.
-    resource_update_timer_->enableTimer(update_interval);
-  });
+  resource_update_timer_ =
+      main_dispatcher_->createTimer([this, update_interval]() {
+        if (!background_threads_running_) {
+          return;
+        }
+        // Resource-update dispatch hooks in here when enabled.
+        resource_update_timer_->enableTimer(update_interval);
+      });
   resource_update_timer_->enableTimer(update_interval);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1524,6 +1524,17 @@ target_link_libraries(test_http_sse_filter_chain_factory
 )
 add_test(NAME HttpSseFilterChainFactoryTest COMMAND test_http_sse_filter_chain_factory)
 
+add_executable(test_sse_session_registry filter/test_sse_session_registry.cc)
+target_link_libraries(test_sse_session_registry
+    gopher-mcp
+    gopher-mcp-event
+    gtest
+    gtest_main
+    gmock
+    Threads::Threads
+)
+add_test(NAME SseSessionRegistryTest COMMAND test_sse_session_registry)
+
 add_executable(test_http_sse_filter_chain_mode filter/test_http_sse_filter_chain_mode.cc)
 target_link_libraries(test_http_sse_filter_chain_mode
     gopher-mcp

--- a/tests/filter/test_sse_session_registry.cc
+++ b/tests/filter/test_sse_session_registry.cc
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for mcp::filter::SseSessionRegistry.
+ *
+ * The registry is the piece that maps an SSE session ID to the long-
+ * lived SSE-stream connection, so a short-lived POST /callback/{id}
+ * handler can hand its JSON-RPC response back through the matching
+ * stream. These tests verify, in order of complexity:
+ *
+ *   1. Pure state-machine behavior (unique IDs, removal, lookups) — no
+ *      real Connection needed, so we store a null pointer and never
+ *      call sendResponse on those slots.
+ *   2. sendResponse against a real socketpair-backed ConnectionImpl —
+ *      we read the bytes off the peer IoHandle and confirm they arrived
+ *      on the wire, which exercises the filter/write path rather than
+ *      mocking it out.
+ *
+ * Dispatcher invariants: every registry method asserts that it runs on
+ * the dispatcher thread, so every test body is wrapped in
+ * executeInDispatcher() to keep that contract honest.
+ */
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "mcp/buffer.h"
+#include "mcp/filter/sse_session_registry.h"
+#include "mcp/network/connection_impl.h"
+#include "mcp/network/socket_impl.h"
+#include "mcp/network/transport_socket.h"
+#include "mcp/stream_info/stream_info_impl.h"
+
+#include "../integration/real_io_test_base.h"
+
+namespace mcp {
+namespace filter {
+namespace {
+
+using namespace std::chrono_literals;
+
+class SseSessionRegistryTest : public test::RealIoTestBase {
+ protected:
+  // Build a server-side ConnectionImpl wrapped around one end of a real
+  // TCP socketpair, plus the raw peer IoHandle so the test can observe
+  // bytes that the connection writes. Must be called from the
+  // dispatcher thread because socket creation and ConnectionImpl
+  // construction both assert it.
+  struct Endpoint {
+    std::unique_ptr<network::ServerConnection> conn;
+    network::IoHandlePtr peer;
+    std::shared_ptr<stream_info::StreamInfo> stream_info;
+  };
+
+  Endpoint makeLiveConnection() {
+    auto pair = createSocketPair();
+    auto local = network::Address::parseInternetAddress("127.0.0.1", 0);
+    auto remote = network::Address::parseInternetAddress("127.0.0.1", 0);
+    auto socket = std::make_unique<network::ConnectionSocketImpl>(
+        std::move(pair.first), local, remote);
+    auto transport = std::make_unique<network::RawBufferTransportSocket>();
+    auto stream_info = std::make_shared<stream_info::StreamInfoImpl>();
+    auto conn = network::ConnectionImpl::createServerConnection(
+        *dispatcher_, std::move(socket), std::move(transport), *stream_info);
+    return Endpoint{std::move(conn), std::move(pair.second),
+                    std::move(stream_info)};
+  }
+
+  // Read up to `budget` milliseconds of whatever the peer has buffered.
+  // IoHandle::read fills an OwnedBuffer; we drain it to a std::string so
+  // tests can string-match the payload the registry routed.
+  std::string drainPeer(network::IoHandle& peer,
+                        std::chrono::milliseconds budget = 1000ms) {
+    std::string out;
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+      OwnedBuffer buf;
+      auto r = peer.read(buf, /*max_length=*/4096);
+      if (r.ok() && *r > 0) {
+        out.append(buf.toString());
+      } else if (!out.empty()) {
+        // Got something and nothing more is coming right now — good
+        // enough. Bail before the full budget elapses.
+        return out;
+      } else {
+        std::this_thread::sleep_for(5ms);
+      }
+    }
+    return out;
+  }
+};
+
+// ----------------------------------------------------------------------
+// State-machine tests (no live Connection needed).
+// ----------------------------------------------------------------------
+
+TEST_F(SseSessionRegistryTest, RegisterReturnsUniqueIds) {
+  executeInDispatcher([this]() {
+    SseSessionRegistry registry(*dispatcher_);
+
+    const std::string a = registry.registerSession(nullptr);
+    const std::string b = registry.registerSession(nullptr);
+    const std::string c = registry.registerSession(nullptr);
+
+    EXPECT_NE(a, b);
+    EXPECT_NE(b, c);
+    EXPECT_NE(a, c);
+    EXPECT_EQ(registry.sessionCount(), 3u);
+    EXPECT_TRUE(registry.hasSession(a));
+    EXPECT_TRUE(registry.hasSession(b));
+    EXPECT_TRUE(registry.hasSession(c));
+  });
+}
+
+TEST_F(SseSessionRegistryTest, RemoveSessionClearsLookup) {
+  executeInDispatcher([this]() {
+    SseSessionRegistry registry(*dispatcher_);
+    const std::string id = registry.registerSession(nullptr);
+    ASSERT_TRUE(registry.hasSession(id));
+
+    registry.removeSession(id);
+    EXPECT_FALSE(registry.hasSession(id));
+    EXPECT_EQ(registry.sessionCount(), 0u);
+  });
+}
+
+TEST_F(SseSessionRegistryTest, RemoveUnknownSessionIsSafeNoop) {
+  executeInDispatcher([this]() {
+    SseSessionRegistry registry(*dispatcher_);
+    // Filter destructor can call removeSession after an already-cleaned
+    // entry (e.g. same session removed twice on teardown). Must not
+    // crash or change state.
+    registry.removeSession("never_registered");
+    EXPECT_EQ(registry.sessionCount(), 0u);
+  });
+}
+
+TEST_F(SseSessionRegistryTest, SendResponseUnknownSessionReturnsFalse) {
+  executeInDispatcher([this]() {
+    SseSessionRegistry registry(*dispatcher_);
+    // Contract: the POST /callback handler expects sendResponse to
+    // return false if the SSE stream is already gone, so it can drop
+    // the response rather than pretending it was delivered.
+    EXPECT_FALSE(registry.sendResponse("vanished", "{}"));
+  });
+}
+
+TEST_F(SseSessionRegistryTest, RemovedSessionNoLongerRoutes) {
+  executeInDispatcher([this]() {
+    SseSessionRegistry registry(*dispatcher_);
+    const std::string id = registry.registerSession(nullptr);
+    registry.removeSession(id);
+    // After removal, any late POST /callback must not dereference the
+    // stale pointer. Verified by: sendResponse returns false and
+    // doesn't touch the null connection.
+    EXPECT_FALSE(registry.sendResponse(id, "{}"));
+  });
+}
+
+TEST_F(SseSessionRegistryTest, MultipleSessionsAreIndependent) {
+  executeInDispatcher([this]() {
+    SseSessionRegistry registry(*dispatcher_);
+    const std::string a = registry.registerSession(nullptr);
+    const std::string b = registry.registerSession(nullptr);
+    ASSERT_EQ(registry.sessionCount(), 2u);
+
+    // Dropping one leaves the other intact — a server with multiple
+    // live clients must not lose the rest when one disconnects.
+    registry.removeSession(a);
+    EXPECT_FALSE(registry.hasSession(a));
+    EXPECT_TRUE(registry.hasSession(b));
+    EXPECT_EQ(registry.sessionCount(), 1u);
+  });
+}
+
+// ----------------------------------------------------------------------
+// Live-write test (real ConnectionImpl over a TCP socketpair).
+// ----------------------------------------------------------------------
+
+TEST_F(SseSessionRegistryTest, SendResponseWritesBytesToRegisteredConnection) {
+  network::IoHandlePtr peer;
+  std::unique_ptr<network::ServerConnection> conn;
+  std::shared_ptr<stream_info::StreamInfo> stream_info;
+  std::string session_id;
+
+  executeInDispatcher([&]() {
+    auto ep = makeLiveConnection();
+    peer = std::move(ep.peer);
+    conn = std::move(ep.conn);
+    stream_info = std::move(ep.stream_info);
+
+    SseSessionRegistry registry(*dispatcher_);
+    session_id = registry.registerSession(conn.get());
+
+    const std::string payload =
+        R"({"jsonrpc":"2.0","id":1,"result":{"ok":true}})";
+    EXPECT_TRUE(registry.sendResponse(session_id, payload));
+
+    // Registry lives only for the duration of this lambda; the
+    // connection outlives it. That mirrors production where the
+    // factory (owning the registry) and the connection have
+    // independent lifetimes — removeSession must be called if the
+    // registry outlives the connection, but here we tear the
+    // registry down first, which is always safe.
+  });
+
+  // On the dispatcher thread the write queued bytes but the actual
+  // send happens asynchronously when the socket reports writable.
+  // Drain with a short budget — the loopback pair is effectively
+  // instant once the write event fires.
+  const std::string wire = drainPeer(*peer, 1000ms);
+  EXPECT_NE(wire.find(R"("result":{"ok":true})"), std::string::npos)
+      << "expected JSON payload on peer socket, got: " << wire;
+
+  // Close the connection on the dispatcher thread so teardown is
+  // ordered correctly — freeing ConnectionImpl from the test thread
+  // would trip the isThreadSafe() assert in its destructor.
+  executeInDispatcher([&]() {
+    conn->close(network::ConnectionCloseType::NoFlush);
+    conn.reset();
+  });
+}
+
+}  // namespace
+}  // namespace filter
+}  // namespace mcp


### PR DESCRIPTION
## Summary
- Implement the server side of MCP's SSE transport inside `HttpSseJsonRpcProtocolFilter`: long-lived `GET {sse_path}` opens a stream, the server announces a `callback/{session_id}` URL via `event: endpoint`, and subsequent `POST /callback/{session_id}` bodies are 202 Accepted while the real JSON-RPC response is routed back through the matching SSE stream.
- Introduce `SseSessionRegistry`, owned by `HttpSseFilterChainFactory` (not a process singleton), mapping session IDs to the SSE-stream `Connection*`. Lifetime is bounded by the server; all access is on the dispatcher thread, asserted but lock-free.
- Add configurable `sse_path`, `rpc_path`, and `external_url` to `McpServerConfig` + `HttpSseFilterChainFactory`, wire them through `McpServer`'s fallback factory construction, and default `http_sse_path` to `/sse` to match the Python/TypeScript MCP SDKs.
- Match `POST /callback/{id}` anywhere in the request path so deployments behind a reverse proxy (Traefik, nginx, ingress) that rewrites the URL still route correctly when `external_url` is set to the proxy-side base.

## Design notes
- **Per-factory registry, not a global singleton.** The upstream draft used a process-wide map guarded by `std::mutex` with cross-thread `connection->write()` calls. That conflicts with the dispatcher-thread invariant and the project preference for state machines over mutex-guarded shared state, and leaks session IDs across `McpServer` instances in the same process. A per-factory registry keeps lifetime bounded by the server and needs no lock because all filter callbacks run on the same dispatcher thread — asserted on every registry entry point.
- **Filter owns the registration lifecycle.** `registerSession` in `onHeaders` for `GET {sse_path}`; `removeSession` in the filter destructor when the SSE-stream connection tears down. Both run on the dispatcher thread per the filter/connection contract, so a `POST /callback` arriving in the narrow "SSE closed but filter not yet destructed" window sees an already-consistent registry and returns a clean lookup miss.
- **Handshake write re-entry.** `onHeaders` writes the HTTP 200 prelude + `event: endpoint` inline via `connection().write()`. An `sse_writing_handshake_` pass-through flag keeps our own `onWrite` from re-framing those raw bytes as an SSE event when the write chain calls back in — the alternative (posting through the dispatcher) would race the client reading the handshake before we could register the session.
- **Response routing via StopIteration.** When `sse_callback_session_id_` is set on the POST connection, `onWrite` drains the response buffer, hands the JSON to the registry, and returns `StopIteration` so the JSON never lands on the POST connection (which already got its 202).
- **Reverse-proxy callback match.** Changed the POST match from "path begins with `/callback/`" to "path contains `/callback/` anywhere," using `rfind` to recover the session ID from the tail. Direct deployments still work because there is only one `/callback/` occurrence and `rfind` lands at position 0.
- **Intentionally diverges from upstream in two places.** (1) No `active_connections_` post-based deferral rewrite — the PR #212 crash-fix stack already replaced that with `Dispatcher::deferredDelete`, which is the correct primitive and handles the use-after-free window that `post()` only partially covers. (2) No debug request-log line in the reverse-proxy fix — it's noise, not part of the routing change.

## Files
- `include/mcp/server/mcp_server.h` — `http_sse_path` default becomes `/sse`; new `external_url` field.
- `include/mcp/filter/http_sse_filter_chain_factory.h` — ctor takes trailing `sse_path`, `rpc_path`, `external_url`; forward-declares `SseSessionRegistry`; out-of-line ctor/dtor to accommodate the `unique_ptr` member.
- `src/filter/http_sse_filter_chain_factory.cc` — `SseSessionRegistry` class; `HttpSseJsonRpcProtocolFilter` gets server-transport state (`sse_server_mode_`, `sse_writing_handshake_`, `sse_session_id_`, `sse_callback_session_id_`) and the `onHeaders` / `onWrite` / `onBody` transport paths.
- `src/server/mcp_server.cc` — fallback factory construction now passes `http_sse_path`, `http_rpc_path`, and `external_url` through.

## Test plan
- [x] All 10 existing `HttpSse` / `HttpsSse` / `SseCodec` / `HttpCodecSse` cases still pass — the new transport is opt-in via the `GET {sse_path}` / `POST /callback/{id}` URL pattern; factories that don't use those paths see no behavioral change.
- [x] `cmake --build build --target gopher-mcp` clean.
- [x] No references to legacy `http_transport_socket.h`.
- [x] Dispatcher-thread asserts on every `SseSessionRegistry` entry point; registry mutation all happens from filter callbacks.
- [ ] Real-IO integration test (full `GET /sse` → endpoint announce → `POST /callback/{id}` → response routed back through stream) will follow as part of PR D alongside the other integration-level tests carved out of #212.

## Context

Third carve-out from PR #211's larger "feature/gateway-sse-transport" bundle, following the crash fixes in #212 and the async HTTP client in #213. This PR lands the SSE server transport that uses the async HTTP client's counterpart direction — POST callback response routing via a session registry. The remaining integration-level tests (including a round-trip test for this transport) will follow as PR D.