### PR TITLE
Drain active_connections_ in McpServer::shutdown and cover the contract

### DIFF
--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -388,24 +388,39 @@ void McpServer::shutdown() {
   // Close all connections in dispatcher context
   if (main_dispatcher_) {
     main_dispatcher_->post([this]() {
-      // IMPROVEMENT: Stop listeners using TcpActiveListener (production
-      // pattern) This provides coordinated shutdown with proper connection
-      // draining
+      // Stop listeners first so no new connections slip in while we drain.
       for (auto& listener : tcp_listeners_) {
         listener->disable();
       }
       tcp_listeners_.clear();
 
-      // Close legacy connection managers (for stdio)
+      // Drain active_connections_ on the dispatcher thread so each
+      // ConnectionImpl destructor fires its closeSocket(LocalClose) here
+      // rather than on whatever thread ends up running ~McpServer. That
+      // routes LocalClose through the per-connection adapter back into
+      // onConnectionLifecycleEvent, which asserts dispatcher-thread.
+      //
+      // server_running_ has already flipped to false above, so the
+      // container-unwind branch inside onConnectionLifecycleEvent is
+      // skipped — otherwise each destruction would try to erase its own
+      // element from the vector we are currently clearing, which would
+      // invalidate iterators and drop adapters referenced by
+      // still-running callback chains.
+      //
+      // Order matters: connections must die before their lifecycle
+      // adapters. The connection's callback list still references the
+      // adapter during ~ConnectionImpl's closeSocket; destroying the
+      // adapter first would be a use-after-free on that last callback.
+      active_connections_.clear();
+      lifecycle_callbacks_.clear();
+
+      // Close legacy connection managers (for stdio).
       for (auto& conn_manager : connection_managers_) {
         conn_manager->close();
       }
       connection_managers_.clear();
 
-      // Clear all sessions
-      // Session cleanup will happen automatically
-
-      // Exit the blocking dispatch loop
+      // Exit the blocking dispatch loop.
       main_dispatcher_->exit();
     });
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1557,6 +1557,17 @@ target_link_libraries(test_mcp_client_initialize_routing
 )
 add_test(NAME McpClientInitializeRoutingTest COMMAND test_mcp_client_initialize_routing)
 
+add_executable(test_mcp_server_connection_lifecycle integration/test_mcp_server_connection_lifecycle.cc)
+target_link_libraries(test_mcp_server_connection_lifecycle
+    gopher-mcp
+    gopher-mcp-event
+    gtest
+    gtest_main
+    gmock
+    Threads::Threads
+)
+add_test(NAME McpServerConnectionLifecycleTest COMMAND test_mcp_server_connection_lifecycle)
+
 add_executable(test_http_sse_filter_chain_mode filter/test_http_sse_filter_chain_mode.cc)
 target_link_libraries(test_http_sse_filter_chain_mode
     gopher-mcp

--- a/tests/integration/test_mcp_client_initialize_routing.cc
+++ b/tests/integration/test_mcp_client_initialize_routing.cc
@@ -148,39 +148,25 @@ class McpClientInitializeRoutingTest : public ::testing::Test {
 
   void TearDown() override {
     // Client first so the server sees a RemoteClose on its still-
-    // running dispatcher. In principle the server's
-    // onConnectionLifecycleEvent handler is supposed to take the
-    // active_connections_ erase + deferredDelete path on RemoteClose.
+    // running dispatcher. The server's onConnectionLifecycleEvent
+    // takes the active_connections_ erase + deferredDelete path on
+    // RemoteClose.
     if (client_) {
       client_->shutdown();
       client_.reset();
     }
-    std::this_thread::sleep_for(500ms);
 
+    // server_->shutdown() drains active_connections_ on the
+    // dispatcher thread inside its cleanup post, so by the time
+    // server_.reset() runs on this thread there are no connections
+    // left whose destructors would fire on the wrong thread.
     if (server_) {
       server_->shutdown();
     }
     if (server_thread_.joinable()) {
       server_thread_.join();
     }
-
-    // Deliberately leak the McpServer. Preexisting teardown bug:
-    // McpServer::shutdown() flips server_running_=false on the caller
-    // thread before posting any cleanup, and the shutdown post itself
-    // never clears active_connections_. That leaves connections alive
-    // into ~McpServer, whose destruction runs on this (test) thread;
-    // each ConnectionImpl destructor fires closeSocket(LocalClose),
-    // which forwards through the lifecycle adapter into
-    // McpServer::onConnectionLifecycleEvent — which asserts it is on
-    // the dispatcher thread (mcp_server.cc:804).
-    //
-    // Fixing that is squarely in the server-lifecycle test's scope,
-    // not this one. Here we just need the client-side routing
-    // contract verified and a clean test exit. Leaking the server is
-    // the least-bad workaround: the process is about to exit so the
-    // OS reclaims the heap, and the dispatcher thread has already
-    // joined so there's no live thread touching the object.
-    (void)server_.release();
+    server_.reset();
   }
 
   // Try to open a TCP connection to the given loopback port until it

--- a/tests/integration/test_mcp_server_connection_lifecycle.cc
+++ b/tests/integration/test_mcp_server_connection_lifecycle.cc
@@ -1,0 +1,302 @@
+/**
+ * Integration test: McpServer connection-lifecycle cleanup + shutdown drain.
+ *
+ * The observable contract under test (the drain fix in McpServer::shutdown):
+ *
+ *   1. Connect/close cycles against the server don't wedge the dispatcher.
+ *      If the per-connection ConnectionLifecycleCallbacks adapter failed to
+ *      erase its entry from active_connections_/lifecycle_callbacks_ on
+ *      RemoteClose, subsequent connections would still work (they get their
+ *      own slots) but the server would leak entries that outlive the
+ *      dispatcher into ~McpServer. We stress this with three sequential
+ *      connect/close cycles and require the listener to keep accepting.
+ *
+ *   2. McpServer::shutdown() tears down with a still-open connection --
+ *      this is the drain path the fix added. The shutdown post clears
+ *      active_connections_ on the dispatcher thread so each ConnectionImpl
+ *      destructor fires closeSocket(LocalClose) there, rather than on
+ *      whatever thread ends up running ~McpServer. Two observable effects:
+ *
+ *        a. The client socket, still open on the test thread, reads 0
+ *           (EOF) after the server shuts down -- proof the server-side
+ *           fd was actually closed by the drain.
+ *
+ *        b. ~McpServer returns normally. Pre-fix, ~McpServer destroyed
+ *           active_connections_ on the caller thread, which triggered
+ *           closeSocket(LocalClose) -> the lifecycle adapter ->
+ *           McpServer::onConnectionLifecycleEvent, whose first line
+ *           asserts dispatcher-thread. The test process crashed at
+ *           teardown. With the fix, teardown is clean.
+ *
+ * We drive the lifecycle with a raw TCP client rather than a full
+ * McpClient because the lifecycle adapter only observes transport-level
+ * ConnectionEvent values; no HTTP or JSON-RPC parsing is required to
+ * exercise the drain contract, and keeping the client dumb isolates the
+ * test to the server-side callback routing.
+ */
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "mcp/buffer.h"
+#include "mcp/network/address.h"
+#include "mcp/network/io_handle.h"
+#include "mcp/network/socket_interface.h"
+#include "mcp/server/mcp_server.h"
+#include "mcp/types.h"
+
+namespace mcp {
+namespace {
+
+using namespace std::chrono_literals;
+
+// Bind ephemeral 0 to get a port the kernel thinks is free, then let go
+// of it and hand the number to the server. Same mild TOCTOU as the other
+// integration tests -- accepted on a loopback test bed.
+uint16_t pickEphemeralPort() {
+  auto& iface = network::socketInterface();
+
+  auto fd_result = iface.socket(network::SocketType::Stream,
+                                network::Address::Type::Ip,
+                                network::Address::IpVersion::v4);
+  if (!fd_result.ok()) {
+    throw std::runtime_error("pickEphemeralPort: socket() failed");
+  }
+
+  auto handle = iface.ioHandleForFd(*fd_result, /*socket_v6only=*/false);
+  handle->setBlocking(false);
+
+  auto bind_addr = network::Address::parseInternetAddress("127.0.0.1", 0);
+  auto bind_result = handle->bind(bind_addr);
+  if (!bind_result.ok()) {
+    throw std::runtime_error("pickEphemeralPort: bind() failed");
+  }
+
+  auto local_addr_result = handle->localAddress();
+  if (!local_addr_result.ok()) {
+    throw std::runtime_error("pickEphemeralPort: localAddress() failed");
+  }
+
+  const auto* ip =
+      dynamic_cast<const network::Address::Ip*>(local_addr_result->get());
+  if (ip == nullptr) {
+    throw std::runtime_error("pickEphemeralPort: not an IP address");
+  }
+  uint16_t port = ip->port();
+  handle->close();
+  return port;
+}
+
+class McpServerConnectionLifecycleTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    port_ = pickEphemeralPort();
+
+    server::McpServerConfig config;
+    config.server_name = "lifecycle-test-server";
+    config.server_version = "0.0.1";
+    config.supported_transports = {TransportType::HttpSse};
+    config.num_workers = 1;
+
+    server_ = server::createMcpServer(config);
+    ASSERT_NE(server_, nullptr);
+
+    const std::string listen_address =
+        "http://127.0.0.1:" + std::to_string(port_);
+    auto listen_result = server_->listen(listen_address);
+    ASSERT_TRUE(holds_alternative<std::nullptr_t>(listen_result))
+        << "McpServer::listen failed";
+
+    // run() blocks; every dispatcher-thread callback in this test runs
+    // inside that thread.
+    server_thread_ = std::thread([this]() { server_->run(); });
+
+    ASSERT_TRUE(waitForListenerReady(port_, 5s))
+        << "Server did not begin accepting on port " << port_;
+  }
+
+  void TearDown() override {
+    // With the shutdown-drain fix in place, shutting down before
+    // destroying the server is safe: the shutdown post clears
+    // active_connections_ and lifecycle_callbacks_ on the dispatcher
+    // thread, so ~McpServer finds empty containers. If a test already
+    // shut the server down explicitly, shutdown() is a no-op.
+    if (server_) {
+      server_->shutdown();
+    }
+    if (server_thread_.joinable()) {
+      server_thread_.join();
+    }
+    server_.reset();
+  }
+
+  // Open a blocking connection probe until the listener accepts or the
+  // budget elapses. listen()/performListen() is two-step; the listener
+  // only starts accepting once the dispatcher picks it up.
+  static bool waitForListenerReady(uint16_t port,
+                                   std::chrono::milliseconds budget) {
+    auto& iface = network::socketInterface();
+    auto addr = network::Address::parseInternetAddress("127.0.0.1", port);
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+      auto fd_result = iface.socket(network::SocketType::Stream,
+                                    network::Address::Type::Ip,
+                                    network::Address::IpVersion::v4);
+      if (fd_result.ok()) {
+        auto handle = iface.ioHandleForFd(*fd_result, false);
+        handle->setBlocking(true);
+        auto connect_result = handle->connect(addr);
+        handle->close();
+        if (connect_result.ok()) {
+          return true;
+        }
+      }
+      std::this_thread::sleep_for(25ms);
+    }
+    return false;
+  }
+
+  // Open a blocking TCP connection to the listener. Returned handle
+  // owns the fd; dropping it (or calling close()) sends FIN and lets
+  // the server see RemoteClose.
+  network::IoHandlePtr openClient() {
+    auto& iface = network::socketInterface();
+    auto fd_result = iface.socket(network::SocketType::Stream,
+                                  network::Address::Type::Ip,
+                                  network::Address::IpVersion::v4);
+    if (!fd_result.ok()) {
+      return nullptr;
+    }
+    auto handle = iface.ioHandleForFd(*fd_result, /*socket_v6only=*/false);
+    handle->setBlocking(true);
+    auto addr = network::Address::parseInternetAddress("127.0.0.1", port_);
+    auto connect_result = handle->connect(addr);
+    if (!connect_result.ok()) {
+      handle->close();
+      return nullptr;
+    }
+    return handle;
+  }
+
+  // Poll a blocking read for EOF (return value of 0) within a budget.
+  // When the server closes its side, the kernel sends FIN and the next
+  // blocking read on the client side returns 0.
+  static bool waitForEof(network::IoHandle& handle,
+                         std::chrono::milliseconds budget) {
+    handle.setBlocking(false);
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+      OwnedBuffer buf;
+      auto r = handle.read(buf, /*max_length=*/4096);
+      if (r.ok()) {
+        // read() returning 0 bytes on a non-error result is EOF on this
+        // IoHandle abstraction.
+        if (*r == 0) {
+          return true;
+        }
+        // Got some bytes -- not what we expected, but keep polling.
+      } else if (!r.wouldBlock()) {
+        // Any non-wouldblock error on read means the peer is gone.
+        return true;
+      }
+      std::this_thread::sleep_for(10ms);
+    }
+    return false;
+  }
+
+  uint16_t port_{0};
+  std::unique_ptr<server::McpServer> server_;
+  std::thread server_thread_;
+};
+
+// Repeated connect/close cycles don't wedge the listener. Each cycle
+// relies on the lifecycle adapter firing RemoteClose on the dispatcher
+// and erasing the connection from active_connections_ /
+// lifecycle_callbacks_ on the deferred-delete queue. If that path ever
+// failed to run, entries would accumulate and the third connect might
+// still succeed at the TCP layer but leave dead state behind -- which
+// would crash ~McpServer during TearDown.
+TEST_F(McpServerConnectionLifecycleTest, RepeatedConnectCloseCyclesStayStable) {
+  for (int i = 0; i < 3; ++i) {
+    auto client = openClient();
+    ASSERT_NE(client, nullptr) << "connect #" << i << " failed";
+    // Drop the handle -> FIN -> server sees RemoteClose on its
+    // dispatcher, runs the unwind branch of onConnectionLifecycleEvent,
+    // and deferred-deletes the adapter + connection. Give the
+    // dispatcher a beat to actually pick up the close before the next
+    // iteration opens a fresh connection.
+    client->close();
+    client.reset();
+    std::this_thread::sleep_for(50ms);
+  }
+
+  // The server should still be accepting. If the lifecycle path had
+  // wedged, the next connect would eventually hang or fail.
+  auto sanity = openClient();
+  EXPECT_NE(sanity, nullptr) << "listener stopped accepting after 3 cycles";
+  if (sanity) {
+    sanity->close();
+  }
+}
+
+// The shutdown-drain contract. Hold a connection open, shut the server
+// down, and verify two things that are only true if the drain ran:
+//
+//   1. The client-side read returns EOF. The drain called
+//      closeSocket(LocalClose) on the server side, which closed the
+//      fd, which shows up on the client as FIN.
+//
+//   2. TearDown runs to completion without the process aborting.
+//      Pre-fix, ~McpServer destroyed active_connections_ on the test
+//      thread and the connection destructor fired LocalClose there,
+//      which reaches onConnectionLifecycleEvent's dispatcher-thread
+//      assert (mcp_server.cc:804) and kills the process.
+TEST_F(McpServerConnectionLifecycleTest, ShutdownClosesLiveConnections) {
+  auto client = openClient();
+  ASSERT_NE(client, nullptr) << "initial TCP connect failed";
+
+  // Small settle so the server has definitely added the connection
+  // to active_connections_ before we initiate shutdown. 50ms is
+  // plenty on loopback; not a real correctness dependency -- missing
+  // the window just means the drain has nothing to do, which is fine.
+  std::this_thread::sleep_for(50ms);
+
+  // Kick off shutdown. Under the fix, the shutdown post clears
+  // active_connections_ and lifecycle_callbacks_ on the dispatcher
+  // thread; each ConnectionImpl destructor fires LocalClose there and
+  // then closes the underlying fd.
+  server_->shutdown();
+  if (server_thread_.joinable()) {
+    server_thread_.join();
+  }
+
+  // Client must see EOF because the server actually closed its side.
+  // A pure dispatcher-exit without draining would leave the server fd
+  // open until ~McpServer -- and the test would only see EOF after
+  // server_.reset(), which is also where the pre-fix assert fires.
+  ASSERT_TRUE(waitForEof(*client, 2s))
+      << "client never saw EOF -- server didn't close its side during drain";
+
+  client->close();
+  client.reset();
+
+  // Explicit reset here, on purpose: the drain path is supposed to
+  // leave active_connections_/lifecycle_callbacks_ empty by the time
+  // the dispatcher has exited, so ~McpServer is a plain destruction
+  // with no cross-thread callback hazards. If the assert fires, gtest
+  // will report an abort; if the destructor returns normally, the
+  // drain did what it was meant to.
+  server_.reset();
+  // Prevent TearDown's shutdown() from running against a moved-from
+  // unique_ptr (server_.reset() already nulled it).
+  SUCCEED();
+}
+
+}  // namespace
+}  // namespace mcp


### PR DESCRIPTION
## Summary

Fix the pre-existing `McpServer` teardown bug and cover the lifecycle+drain contract end-to-end, then drop the leak workaround the previous integration test needed around it.

Three commits, each independently reviewable:

1. **`McpServer::shutdown` drain fix** (`src/server/mcp_server.cc`) — `shutdown()` now clears `active_connections_` and `lifecycle_callbacks_` inside the cleanup post on the dispatcher thread, so each `ConnectionImpl` destructor fires `closeSocket(LocalClose)` there rather than on whichever thread ends up running `~McpServer`. Two correctness details are documented in the commit message:
   - `server_running_` is already `false` by the time the post runs, so the container-unwind branch inside `onConnectionLifecycleEvent` is skipped — otherwise each synchronous `LocalClose` would try to erase its own element from the vector we're actively clearing.
   - Connections are cleared before their lifecycle adapters. The connection's callback list still references the adapter during the final `closeSocket` in `~ConnectionImpl`; destroying the adapter first would be a use-after-free on that last callback.

2. **Integration test** (`tests/integration/test_mcp_server_connection_lifecycle.cc`) — two real-IO tests against a loopback `McpServer`:
   - `RepeatedConnectCloseCyclesStayStable` — three sequential connect/close cycles, then verify the listener is still accepting.
   - `ShutdownClosesLiveConnections` — hold a client TCP connection open, call `shutdown()`, and assert both that the client reads EOF (proving the drain actually closed the server-side fd) and that `server_.reset()` returns normally (proving the drain emptied the containers before `~McpServer`).
   
   I confirmed the second test reproduces the exact `onConnectionLifecycleEvent off dispatcher` assert at `mcp_server.cc:804` against the pre-fix `mcp_server.cc`; under the fix both tests pass.

3. **Drop the leak workaround in the initialize-routing test** — the earlier integration test deliberately `release()`d the server because shutdown couldn't clean up connections. With the drain fix it can, so the workaround goes away. As a side benefit the 500 ms drain sleep also disappears, cutting the test's wall time from ~650 ms to ~140 ms.

## Test plan

- [x] `ctest -R \"[Mm]cp|[Ss]erver|[Ss]se|[Hh]ttp\"` — 38/38 pass
- [x] New lifecycle test passes 5× in a row (~270 ms each)
- [x] Reverted the fix locally and re-ran the new lifecycle test — reproduces the pre-fix `line 804` assert, confirming the test is actually guarding the contract