### PR TITLE
Clean up McpServer connection-callback surface

### DIFF
--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -688,8 +688,7 @@ class SessionManager {
  * 4. McpServer handles protocol logic
  */
 class McpServer : public application::ApplicationBase,
-                  public network::ListenerCallbacks,
-                  public network::ConnectionCallbacks {
+                  public network::ListenerCallbacks {
  public:
   McpServer(const McpServerConfig& config);
   ~McpServer() override;
@@ -791,14 +790,6 @@ class McpServer : public application::ApplicationBase,
   void onAccept(network::ConnectionSocketPtr&& socket) override;
   // Called when connection is fully established with filters
   void onNewConnection(network::ConnectionPtr&& connection) override;
-
-  // ConnectionCallbacks overrides (for connection lifecycle tracking)
-  void onEvent(network::ConnectionEvent event) override {
-    // Forward to existing handler
-    onConnectionEvent(event);
-  }
-  void onAboveWriteBufferHighWatermark() override {}
-  void onBelowWriteBufferLowWatermark() override {}
 
  private:
   // Register built-in handlers

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -927,9 +927,6 @@ class McpServer : public application::ApplicationBase,
   // Following production pattern: listener owns connections, not threads
   // Connections tracked by count only, ownership managed by listener
 
-  // Track connection count for statistics
-  std::atomic<uint64_t> num_connections_{0};
-
   // Current connection being processed (for request context)
   // This is set temporarily during request processing in dispatcher thread
   network::Connection* current_connection_{nullptr};

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -875,7 +875,6 @@ void McpServer::onConnectionLifecycleEvent(network::Connection* connection,
   if (current_connection_ == connection) {
     current_connection_ = nullptr;
   }
-  num_connections_--;
 }
 
 void McpServer::onError(const Error& error) {
@@ -1328,7 +1327,6 @@ void McpServer::onNewConnection(network::ConnectionPtr&& connection) {
   // this call is on the dispatcher thread, so the atomic increments land
   // on the same thread that the decrement in onConnectionLifecycleEvent
   // runs on.
-  ++num_connections_;
   server_stats_.connections_total++;
   server_stats_.connections_active++;
 


### PR DESCRIPTION
## Summary

Two small, mechanical follow-ups to PR #219 that trim dead code from the `McpServer` connection-callback surface now that TCP accepts are properly counted in `onNewConnection`.

1. **Drop vestigial `ConnectionCallbacks` inheritance**. `McpServer` inherited from `network::ConnectionCallbacks` and overrode `onEvent`, `onAboveWriteBufferHighWatermark`, and `onBelowWriteBufferLowWatermark`, but nothing ever registered an `McpServer` instance as a connection's callbacks. Per-TCP-connection events go through the `ConnectionLifecycleCallbacks` adapter (which carries the closing connection's identity); the stdio path reaches `McpServer::onConnectionEvent` through `ServerProtocolCallbacks`, not through `ConnectionCallbacks::onEvent`. `onConnectionEvent` itself stays — it is still the live stats-and-forwarding entry point for stdio transports.
2. **Drop write-only `num_connections_` counter**. It was a private atomic bumped on accept and decremented on close with no reader anywhere in `include/`, `src/`, `tests/`, or `examples/`. `server_stats_.connections_active` is the real, publicly-exposed count via `getServerStats()` and lives on the same code paths. One source of truth instead of two.

## Test plan

- [x] `ctest -R 'McpServer|McpClient|McpInitialize|StdioEcho|TcpEcho'` — 12/12 pass