### PR TITLE
Run deferred connection close through dispatcher.post instead of stack-local timer

### DIFF
--- a/src/network/connection_impl.cc
+++ b/src/network/connection_impl.cc
@@ -990,12 +990,13 @@ void ConnectionImpl::closeThroughFilterManager(ConnectionEvent close_type) {
       file_event_->setEnabled(0);
     }
 
-    // Step 2: Schedule the actual close for the next event loop iteration
-    // The timer with 0 delay ensures closeSocket runs after current stack
-    // unwinds
-    auto close_timer = dispatcher_.createTimer(
-        [this, close_type]() { closeSocket(close_type); });
-    close_timer->enableTimer(std::chrono::milliseconds(0));
+    // Step 2: Run the actual close on the next dispatcher iteration so the
+    // current doRead() / onFileEvent() stack unwinds before the connection
+    // is torn down. dispatcher_.post() queues the callback on the dispatcher
+    // and wakes the loop; unlike a locally-scoped Timer, the queued
+    // callback is owned by the dispatcher so it cannot be cancelled by
+    // stack unwinding.
+    dispatcher_.post([this, close_type]() { closeSocket(close_type); });
   }
 }
 

--- a/tests/integration/test_mcp_server_connection_lifecycle.cc
+++ b/tests/integration/test_mcp_server_connection_lifecycle.cc
@@ -335,6 +335,73 @@ TEST_F(McpServerConnectionLifecycleTest, AcceptedConnectionsAreCounted) {
   // TearDown's shutdown() will no-op on the already-stopped server.
 }
 
+// Peer FIN on a raw TCP client must propagate up to the server's
+// connection-lifecycle callback in bounded time, so the server can
+// reclaim connection state (active_connections_, stats) without
+// depending on an idle-timeout.
+//
+// The observable contract is: once the client sends FIN,
+// connections_active drops back to its baseline well within the TCP
+// keepalive / idle-timeout window. The fix this test guards lives in
+// ConnectionImpl::closeThroughFilterManager(): the read path detects
+// EOF from the transport socket, calls closeThroughFilterManager, and
+// that helper must queue the deferred close on the dispatcher such
+// that the callback survives stack unwinding of the current doRead()
+// frame. A prior implementation used a stack-local Timer, which was
+// destroyed (and the libevent timer cancelled) as soon as the helper
+// returned — so the RemoteClose event never propagated and the
+// connection leaked until the TearDown-driven shutdown.
+//
+// Two variants are covered to exercise both branches of the doRead
+// loop: the "silent close" path goes through
+// RawBufferTransportSocket::doRead -> endStream(0), while the
+// "after-write" path exercises the same EOF detection after the
+// filter chain has already been engaged with real data.
+TEST_F(McpServerConnectionLifecycleTest, RawClientSilentCloseDropsConnection) {
+  const auto& stats = server_->getServerStats();
+  const uint64_t base = stats.connections_active.load();
+
+  auto client = openClient();
+  ASSERT_NE(client, nullptr);
+  ASSERT_TRUE(waitForActiveConnections(base + 1u, 2s));
+
+  client->close();
+  client.reset();
+
+  // Generous bound: the fix drops the connection in single-digit
+  // milliseconds on loopback. 2s is plenty for loaded CI while still
+  // catching the "deferred close never runs" regression, which
+  // previously manifested as a 10s+ hang.
+  ASSERT_TRUE(waitForActiveConnections(base, 2s))
+      << "Server did not observe peer FIN; closeThroughFilterManager "
+         "likely dropped its deferred-close callback.";
+}
+
+TEST_F(McpServerConnectionLifecycleTest, RawClientCloseAfterWriteDropsConnection) {
+  const auto& stats = server_->getServerStats();
+  const uint64_t base = stats.connections_active.load();
+
+  auto client = openClient();
+  ASSERT_NE(client, nullptr);
+  ASSERT_TRUE(waitForActiveConnections(base + 1u, 2s));
+
+  // Send a plausible-looking HTTP prefix so the server's filter chain
+  // engages before FIN arrives. This exercises the EOF path after at
+  // least one successful read, which is a different doRead() trip
+  // than the silent-close case.
+  OwnedBuffer out;
+  out.add("GET / HTTP/1.1\r\n\r\n", 18);
+  auto w = client->write(out);
+  ASSERT_TRUE(w.ok()) << "client write failed";
+
+  client->close();
+  client.reset();
+
+  ASSERT_TRUE(waitForActiveConnections(base, 2s))
+      << "Server did not observe peer FIN after write; deferred-close "
+         "callback likely cancelled.";
+}
+
 // Repeated connect/close cycles don't wedge the listener. Each cycle
 // relies on the lifecycle adapter firing RemoteClose on the dispatcher
 // and erasing the connection from active_connections_ /


### PR DESCRIPTION
## Summary

- `ConnectionImpl::closeThroughFilterManager` scheduled `closeSocket` on a 0-delay `Timer` owned by a stack-local `unique_ptr`. Returning from the helper destroyed the Timer — `event_del` + `event_free` cancelled the libevent registration — and the queued callback never fired. The effect: when a peer sent FIN, `doRead` detected EOF and called the helper, but the deferred `closeSocket` never ran, so `ConnectionLifecycleCallbacks::onEvent(RemoteClose)` was never raised and the server's `active_connections_` / `connections_active` stayed stuck until `shutdown()` tore everything down.
- Switched to `dispatcher_.post(...)`: the dispatcher owns the queued callback, which survives stack unwinding of the current `doRead()` / `onFileEvent()` frame. Same "run on next loop iteration" semantic the 0-delay Timer was trying to express, without the lifetime trap.
- Added two regression tests that drive a raw TCP client against the live server, close it (silent and after a prior write), and assert `connections_active` drops back to baseline within 2s. Both previously hung for 10s+; both now drop in ~10 ms.

## Test plan

- [x] `./tests/test_mcp_server_connection_lifecycle` (all 5 tests pass, including the two new regressions)
- [x] Related unit/integration suites pass: `test_connection_impl`, `test_connection_manager_impl`, `test_connection_manager_real_io`, `test_connection_state_machine`, `test_close_socket_guard`, `test_deferred_delete_ordering`, `test_mcp_connection_manager`, `test_client_disconnect_fixes`, `test_mcp_client_initialize_routing`, `test_mcp_server_responses`
- [x] Full `cmake --build .` is clean