### PR TITLE
Add per-connection idle-read timeout for McpServer (#224)

### DIFF
--- a/include/mcp/network/connection.h
+++ b/include/mcp/network/connection.h
@@ -289,7 +289,7 @@ class Connection : public event::DeferredDeletable,
 
   /**
    * Set the idle-read timeout. If no bytes are successfully read from the
-   * transport within the window, the connection is closed with FlushWrite.
+   * transport within the window, the connection is closed with NoFlush.
    *
    * A zero timeout disables the feature and cancels any pending timer. The
    * timer is (re)armed on each successful read and cancelled on close.

--- a/include/mcp/network/connection.h
+++ b/include/mcp/network/connection.h
@@ -288,6 +288,15 @@ class Connection : public event::DeferredDeletable,
   virtual void setDelayedCloseTimeout(std::chrono::milliseconds timeout) = 0;
 
   /**
+   * Set the idle-read timeout. If no bytes are successfully read from the
+   * transport within the window, the connection is closed with FlushWrite.
+   *
+   * A zero timeout disables the feature and cancels any pending timer. The
+   * timer is (re)armed on each successful read and cancelled on close.
+   */
+  virtual void setIdleReadTimeout(std::chrono::milliseconds timeout) = 0;
+
+  /**
    * Get transport failure reason
    */
   virtual std::string transportFailureReason() const = 0;
@@ -488,6 +497,8 @@ class ConnectionImplBase : public virtual Connection {
   uint32_t buffer_limit_{0};
   std::chrono::milliseconds delayed_close_timeout_{0};
   event::TimerPtr delayed_close_timer_;
+  std::chrono::milliseconds idle_read_timeout_{0};
+  event::TimerPtr idle_read_timer_;
 
   // Close reasons
   std::string local_close_reason_;

--- a/include/mcp/network/connection_impl.h
+++ b/include/mcp/network/connection_impl.h
@@ -90,6 +90,7 @@ class ConnectionImpl : public ConnectionImplBase,
     return socket_options_;
   }
   void setDelayedCloseTimeout(std::chrono::milliseconds timeout) override;
+  void setIdleReadTimeout(std::chrono::milliseconds timeout) override;
   bool startSecureTransport() override;
   optional<std::chrono::milliseconds> lastRoundTripTime() const override;
   uint64_t getWriteEventCount() const override {
@@ -176,6 +177,8 @@ class ConnectionImpl : public ConnectionImplBase,
   // Timer callbacks
   void onDelayedCloseTimeout();
   void onConnectTimeout();
+  void onIdleReadTimeout();
+  void resetIdleReadTimer();
 
   // Helper methods
   void enableFileEvents(uint32_t events);

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -103,6 +103,13 @@ struct McpServerConfig : public application::ApplicationBase::Config {
   std::chrono::milliseconds session_timeout{300000};  // 5 minutes
   bool allow_concurrent_sessions = true;
 
+  // Per-connection idle-read timeout applied to every accepted connection.
+  // If no bytes arrive within the window the connection is closed with
+  // FlushWrite so an in-flight response can still drain. Zero disables
+  // the feature, which is the default so existing deployments see no
+  // behavior change.
+  std::chrono::milliseconds idle_read_timeout{0};
+
   // Request processing
   size_t request_queue_size = 1000;
   std::chrono::milliseconds request_processing_timeout{60000};

--- a/src/network/connection_impl.cc
+++ b/src/network/connection_impl.cc
@@ -665,6 +665,9 @@ void ConnectionImpl::setDelayedCloseTimeout(std::chrono::milliseconds timeout) {
 }
 
 void ConnectionImpl::setIdleReadTimeout(std::chrono::milliseconds timeout) {
+  GOPHER_LOG_DEBUG("setIdleReadTimeout(fd={}, timeout={}ms, state={})",
+                   socket_->ioHandle().fd(), timeout.count(),
+                   static_cast<int>(state_));
   // Zero disables the feature and cancels any pending timer — matches the
   // convention used by setDelayedCloseTimeout so callers can gate the
   // feature at config time without branching on the timeout value.
@@ -680,6 +683,7 @@ void ConnectionImpl::setIdleReadTimeout(std::chrono::milliseconds timeout) {
   // even if no read has occurred yet. Subsequent successful reads rearm
   // via resetIdleReadTimer().
   if (state_ != ConnectionState::Open) {
+    GOPHER_LOG_DEBUG("setIdleReadTimeout: state not Open, skipping arm");
     return;
   }
   if (idle_read_timer_ == nullptr) {
@@ -1637,12 +1641,17 @@ void ConnectionImpl::onConnectTimeout() {
 }
 
 void ConnectionImpl::onIdleReadTimeout() {
-  // Idle peer that stopped sending. FlushWrite gives any in-flight
-  // response a chance to drain before the socket goes away; callers
-  // that want a harder drop can still invoke close(NoFlush) directly.
-  GOPHER_LOG_DEBUG("idle read timeout fired on fd={}; closing with FlushWrite",
+  // Idle peer that stopped sending — drop the socket immediately. NoFlush
+  // is the right pick here for two reasons: (1) a silent peer isn't
+  // waiting on an in-flight write, so there's nothing to drain; and
+  // (2) the close() wrapper for FlushWrite pre-sets state_ to Closing
+  // before calling closeSocket(), which then bails via its
+  // re-entrancy guard — NoFlush is the one ConnectionCloseType that
+  // routes straight to closeSocket() with state still Open, so the
+  // LocalClose event actually propagates to our lifecycle adapter.
+  GOPHER_LOG_DEBUG("idle read timeout fired on fd={}; closing with NoFlush",
                    socket_->ioHandle().fd());
-  close(ConnectionCloseType::FlushWrite, "idle read timeout");
+  close(ConnectionCloseType::NoFlush, "idle read timeout");
 }
 
 void ConnectionImpl::resetIdleReadTimer() {

--- a/src/network/connection_impl.cc
+++ b/src/network/connection_impl.cc
@@ -664,6 +664,31 @@ void ConnectionImpl::setDelayedCloseTimeout(std::chrono::milliseconds timeout) {
   delayed_close_timeout_ = timeout;
 }
 
+void ConnectionImpl::setIdleReadTimeout(std::chrono::milliseconds timeout) {
+  // Zero disables the feature and cancels any pending timer — matches the
+  // convention used by setDelayedCloseTimeout so callers can gate the
+  // feature at config time without branching on the timeout value.
+  idle_read_timeout_ = timeout;
+  if (timeout.count() == 0) {
+    if (idle_read_timer_) {
+      idle_read_timer_->disableTimer();
+    }
+    return;
+  }
+  // The timer is armed here so callers who set the timeout *after* the
+  // connection is already open (e.g., from a filter) still get coverage
+  // even if no read has occurred yet. Subsequent successful reads rearm
+  // via resetIdleReadTimer().
+  if (state_ != ConnectionState::Open) {
+    return;
+  }
+  if (idle_read_timer_ == nullptr) {
+    idle_read_timer_ =
+        dispatcher_.createTimer([this]() { onIdleReadTimeout(); });
+  }
+  idle_read_timer_->enableTimer(idle_read_timeout_);
+}
+
 bool ConnectionImpl::startSecureTransport() {
   return transport_socket_ ? transport_socket_->startSecureTransport() : false;
 }
@@ -1054,6 +1079,9 @@ void ConnectionImpl::closeSocket(ConnectionEvent close_type) {
   if (transport_connect_timer_) {
     transport_connect_timer_->disableTimer();
   }
+  if (idle_read_timer_) {
+    idle_read_timer_->disableTimer();
+  }
 
   // Close transport socket safely
   if (transport_socket_) {
@@ -1289,6 +1317,11 @@ void ConnectionImpl::doRead() {
 
     // Update stats
     updateReadBufferStats(result.bytes_processed_, read_buffer_.length());
+
+    // Any successful read rearms the idle-read timer — kept next to the
+    // stats update so the reset happens before we hand off to user
+    // filters, which may themselves block for a while.
+    resetIdleReadTimer();
 
     // Process through filter chain
     processReadBuffer();
@@ -1601,6 +1634,23 @@ void ConnectionImpl::onDelayedCloseTimeout() {
 
 void ConnectionImpl::onConnectTimeout() {
   closeSocket(ConnectionEvent::LocalClose);
+}
+
+void ConnectionImpl::onIdleReadTimeout() {
+  // Idle peer that stopped sending. FlushWrite gives any in-flight
+  // response a chance to drain before the socket goes away; callers
+  // that want a harder drop can still invoke close(NoFlush) directly.
+  GOPHER_LOG_DEBUG("idle read timeout fired on fd={}; closing with FlushWrite",
+                   socket_->ioHandle().fd());
+  close(ConnectionCloseType::FlushWrite, "idle read timeout");
+}
+
+void ConnectionImpl::resetIdleReadTimer() {
+  // Cheap no-op when the feature is disabled — avoids a branch at every
+  // call site in doRead.
+  if (idle_read_timer_ && idle_read_timeout_.count() > 0) {
+    idle_read_timer_->enableTimer(idle_read_timeout_);
+  }
 }
 
 void ConnectionImpl::enableFileEvents(uint32_t events) {

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -1330,6 +1330,13 @@ void McpServer::onNewConnection(network::ConnectionPtr&& connection) {
   server_stats_.connections_total++;
   server_stats_.connections_active++;
 
+  // Arm the per-connection idle-read timer if the operator configured one.
+  // The setter treats zero as "disabled", so gating here only documents
+  // intent and avoids touching the timer state for the default build.
+  if (config_.idle_read_timeout.count() > 0) {
+    conn_ptr->setIdleReadTimeout(config_.idle_read_timeout);
+  }
+
   // Store the connection to keep it alive
   // Following production pattern: server owns connections in dispatcher thread
   // No mutex needed - all operations happen in dispatcher thread

--- a/tests/integration/test_mcp_server_connection_lifecycle.cc
+++ b/tests/integration/test_mcp_server_connection_lifecycle.cc
@@ -106,6 +106,7 @@ class McpServerConnectionLifecycleTest : public ::testing::Test {
     config.server_version = "0.0.1";
     config.supported_transports = {TransportType::HttpSse};
     config.num_workers = 1;
+    customizeConfig(config);
 
     server_ = server::createMcpServer(config);
     ASSERT_NE(server_, nullptr);
@@ -282,6 +283,11 @@ class McpServerConnectionLifecycleTest : public ::testing::Test {
     }
     return server_->getServerStats().connections_active.load() == expected;
   }
+
+  // Subclasses override to tweak McpServerConfig before the server is
+  // built. Kept as a hook rather than a member so the same fixture can
+  // serve several variants without every test carrying every knob.
+  virtual void customizeConfig(server::McpServerConfig& /*config*/) {}
 
   uint16_t port_{0};
   std::unique_ptr<server::McpServer> server_;
@@ -546,6 +552,92 @@ TEST_F(McpServerConnectionLifecycleTest, ShutdownClosesLiveConnections) {
   // Prevent TearDown's shutdown() from running against a moved-from
   // unique_ptr (server_.reset() already nulled it).
   SUCCEED();
+}
+
+// Configures the server with a short idle-read timeout and verifies that
+// an accepted connection which never sends any bytes is dropped on the
+// server side within the window. This pins the end-to-end wiring:
+//
+//   McpServerConfig::idle_read_timeout
+//     -> McpServer::onNewConnection
+//     -> Connection::setIdleReadTimeout
+//     -> ConnectionImpl idle_read_timer_
+//     -> timer callback closes the connection (FlushWrite)
+//     -> ConnectionLifecycleCallbacks decrements connections_active
+//
+// The window is deliberately tight (200ms) so a regression shows as a
+// test hang-then-failure rather than a multi-second wait; the 3s
+// observation budget absorbs scheduling slack on loaded CI.
+class McpServerIdleReadTimeoutTest : public McpServerConnectionLifecycleTest {
+ protected:
+  void customizeConfig(server::McpServerConfig& config) override {
+    config.idle_read_timeout = std::chrono::milliseconds(200);
+  }
+};
+
+TEST_F(McpServerIdleReadTimeoutTest, IdlePeerDroppedAfterTimeout) {
+  const auto& stats = server_->getServerStats();
+  const uint64_t base = stats.connections_active.load();
+
+  auto client = openClient();
+  ASSERT_NE(client, nullptr);
+  ASSERT_TRUE(waitForActiveConnections(base + 1u, 2s));
+
+  // Do nothing — the whole point is that the peer stays silent. The
+  // server's idle_read_timer_ should fire on the dispatcher thread and
+  // close the connection with FlushWrite, which the lifecycle adapter
+  // observes as LocalClose and decrements connections_active.
+  ASSERT_TRUE(waitForActiveConnections(base, 3s))
+      << "server did not drop idle connection within the idle-read timeout "
+         "window; setIdleReadTimeout wiring likely missing or timer never "
+         "armed";
+
+  // The client sees the server's close as EOF on its blocking read.
+  // Covers the other observable side of the same close: the fd was
+  // actually torn down, not merely removed from bookkeeping.
+  EXPECT_TRUE(waitForEof(*client, 1s))
+      << "client never saw server's close after idle timeout";
+
+  client->close();
+  client.reset();
+}
+
+// Counterpart to the idle-drop test: a peer that keeps sending bytes
+// must not be dropped by the idle-read timer. Pins that
+// resetIdleReadTimer() is actually called on every successful read in
+// ConnectionImpl::doRead() — a broken wiring where the timer only
+// arms once would let this test hit the failure in under 200ms.
+TEST_F(McpServerIdleReadTimeoutTest, ActivePeerIsNotDropped) {
+  const auto& stats = server_->getServerStats();
+  const uint64_t base = stats.connections_active.load();
+
+  auto client = openClient();
+  ASSERT_NE(client, nullptr);
+  ASSERT_TRUE(waitForActiveConnections(base + 1u, 2s));
+
+  // Send a byte every 50ms for ~500ms. The 200ms idle window would
+  // close a silent peer well before the loop ends, so survival past the
+  // loop is proof that each successful transport-level read rearmed
+  // the timer. We deliberately poke the raw transport with non-HTTP
+  // bytes: we're pinning the transport-layer idle timer, and any
+  // filter-layer response to garbage (reject, parse-error close, etc.)
+  // is out of scope for this test and would only flake the assertion
+  // in the other direction (connection dropped too early).
+  for (int i = 0; i < 10; ++i) {
+    OwnedBuffer out;
+    out.add("x", 1);
+    auto w = client->write(out);
+    ASSERT_TRUE(w.ok()) << "client write #" << i << " failed";
+    std::this_thread::sleep_for(50ms);
+  }
+
+  EXPECT_EQ(stats.connections_active.load(), base + 1u)
+      << "active peer was dropped — idle timer did not reset on read";
+
+  // Explicit teardown so we don't lean on TearDown's shutdown drain
+  // to close an otherwise-healthy connection.
+  client->close();
+  client.reset();
 }
 
 }  // namespace

--- a/tests/network/test_transport_socket.cc
+++ b/tests/network/test_transport_socket.cc
@@ -162,6 +162,7 @@ class TestConnection : public Connection {
     return *stream_info_;
   }
   void setDelayedCloseTimeout(std::chrono::milliseconds) override {}
+  void setIdleReadTimeout(std::chrono::milliseconds) override {}
   std::string transportFailureReason() const override { return ""; }
   std::string localCloseReason() const override { return ""; }
   bool startSecureTransport() override { return false; }


### PR DESCRIPTION
## Summary
Adds a per-connection idle-read timeout so operators can reclaim accepted sockets from peers that opened a TCP connection but stopped sending — without leaning on the kernel's much coarser keepalive machinery.

- `Connection::setIdleReadTimeout(ms)` new virtual; implemented by `ConnectionImpl` with an `idle_read_timer_` that (re)arms on every successful transport-level read and is cancelled on close.
- `McpServerConfig::idle_read_timeout` (default 0 = disabled) wired through `McpServer::onNewConnection` so every accepted connection is guarded when configured.
- Idle-timer close uses `ConnectionCloseType::NoFlush`. `FlushWrite` pre-sets `state_ = Closing` before calling `closeSocket()`, whose re-entrancy guard then returns early — so the `LocalClose` event would never reach the lifecycle adapter. `NoFlush` is also semantically right for a silent peer: nothing to drain.

## Why
Long-lived ingress where a peer opens a socket then stalls silently is a real failure mode; until now the only protection was whatever `SO_KEEPALIVE` happened to do on the host. The feature defaults to disabled so existing deployments see no behavior change.

## Test plan
Two new end-to-end tests on a derived `McpServerIdleReadTimeoutTest` fixture (200ms timeout):
- [x] `IdlePeerDroppedAfterTimeout` — silent peer is dropped, client observes EOF.
- [x] `ActivePeerIsNotDropped` — peer sending one byte every 50ms stays alive past the 200ms window (pins the reset-on-read path).
- [x] Full `McpServerConnectionLifecycleTest` suite still green (7/7).
- [x] `test_connection_impl`, `test_connection_manager_impl`, `test_connection_pool_pending_timeout`, `test_connection_pool_callbacks`, `test_transport_socket` all green (no regressions to callers that construct raw `Connection` stubs — `test_transport_socket` stub gets a no-op override).