### PR TITLE
build: Add MSVC 26 support and improve build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ __pycache__/
 # OS generated files
 Thumbs.db
 Desktop.ini
+vcpkg_installed/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,19 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         add_compile_options(-O3)
     endif()
 elseif(MSVC)
-    add_compile_options(/W4 /WX)
+    # Align with GCC/Clang strict mode behavior:
+    # - strict ON  => warnings as errors
+    # - strict OFF => development-friendly warning level
+    if(MCP_STRICT_WARNINGS)
+        add_compile_options(/W4 /WX)
+    else()
+        add_compile_options(/W3 /WX-)
+    endif()
+endif()
+
+# Windows API hygiene: avoid min/max macro pollution and reduce included Win32 headers.
+if(WIN32)
+    add_compile_definitions(NOMINMAX WIN32_LEAN_AND_MEAN)
 endif()
 
 # Memory sanitizer options for debugging
@@ -241,6 +253,8 @@ if(MCP_USE_LLHTTP)
         # Disable warnings for third-party code
         if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
             target_compile_options(llhttp PRIVATE -w)
+        elseif(MSVC)
+            target_compile_options(llhttp PRIVATE /W3 /WX-)
         endif()
     endif()
     
@@ -292,6 +306,9 @@ if(MCP_USE_NGHTTP2)
         # Enable position-independent code for shared library linking
         if(TARGET nghttp2_static)
             set_target_properties(nghttp2_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+            if(MSVC)
+                target_compile_options(nghttp2_static PRIVATE /W3 /WX-)
+            endif()
         endif()
 
         set(NGHTTP2_FOUND TRUE)
@@ -720,6 +737,13 @@ if(BUILD_SHARED_LIBS)
         SOVERSION ${GOPHER_MCP_VERSION_MAJOR}
         POSITION_INDEPENDENT_CODE ON
     )
+
+    if(WIN32)
+        set_target_properties(gopher-mcp-echo-advanced PROPERTIES
+            WINDOWS_EXPORT_ALL_SYMBOLS ON
+            PREFIX ""
+        )
+    endif()
 else()
     add_library(gopher-mcp-echo-advanced ALIAS gopher-mcp-echo-advanced-static)
 endif()
@@ -797,6 +821,13 @@ if(BUILD_SHARED_LIBS)
         SOVERSION ${GOPHER_MCP_VERSION_MAJOR}
         POSITION_INDEPENDENT_CODE ON
     )
+
+    if(WIN32)
+        set_target_properties(gopher-mcp-event PROPERTIES
+            WINDOWS_EXPORT_ALL_SYMBOLS ON
+            PREFIX ""
+        )
+    endif()
 else()
     add_library(gopher-mcp-event ALIAS gopher-mcp-event-static)
 endif()

--- a/include/mcp/event/libevent_dispatcher.h
+++ b/include/mcp/event/libevent_dispatcher.h
@@ -16,7 +16,7 @@ namespace mcp {
 namespace event {
 
 // Rename to avoid conflict with struct event
-using libevent_event = struct event;
+using libevent_event = struct ::event;
 
 // Use libevent's socket type for callback signature compatibility.
 // On Windows, libevent uses intptr_t (SOCKET), on POSIX it uses int.

--- a/include/mcp/logging/log_message.h
+++ b/include/mcp/logging/log_message.h
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #endif
 
+#include "mcp/core/compat.h"
 #include "mcp/logging/log_level.h"
 
 namespace mcp {

--- a/src/config/file_config_source.cc
+++ b/src/config/file_config_source.cc
@@ -49,6 +49,10 @@
 // Platform-specific includes
 #ifdef _WIN32
 #include <windows.h>
+#include <sys/stat.h>
+#ifndef S_ISDIR
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#endif
 #endif
 
 namespace mcp {

--- a/src/logging/CMakeLists.txt
+++ b/src/logging/CMakeLists.txt
@@ -47,7 +47,14 @@ target_compile_definitions(gopher-mcp-logging-static PUBLIC
 # Create shared library
 if(BUILD_SHARED_LIBS)
   add_library(gopher-mcp-logging SHARED ${MCP_LOGGING_SOURCES})
-  
+
+  if(WIN32)
+    set_target_properties(gopher-mcp-logging PROPERTIES
+      WINDOWS_EXPORT_ALL_SYMBOLS ON
+      PREFIX ""
+    )
+  endif()
+
   target_include_directories(gopher-mcp-logging PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "gopher-mcp",
+  "builtin-baseline": "4bc07e3eb00c5a9539a5a7a83415150a9260f8db",
+  "dependencies": [
+    {
+      "name": "openssl"
+    },
+    {
+      "name": "libevent",
+      "features": ["openssl", "thread"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add support for MSVC 26 compiler and improve the overall build configuration for Windows compatibility.

## Changes

- **vcpkg.json**: Introduce manifest-based dependency management for vcpkg integration
- **.gitignore**: Add entries for build artifacts and generated files
- **CMakeLists.txt**: Update root build configuration with MSVC 26 compatibility
- **src/logging/CMakeLists.txt**: configuration with MSVC 26 compatibility
- Improve Windows platform compatibility
  * log_message.h
  * file_config_source.cc
  * libevent_dispatcher.h

## Testing

- [x] Builds successfully on Windows with MSVC 26
- [x] Code formatting passes \make format\
- [x] Build system validates correctly