### PR TITLE
Add client-side notification handler registration to McpClient

### DIFF
--- a/include/mcp/client/mcp_client.h
+++ b/include/mcp/client/mcp_client.h
@@ -480,6 +480,18 @@ class McpClient : public application::ApplicationBase {
       const std::vector<SamplingMessage>& messages,
       const optional<ModelPreferences>& preferences = nullopt);
 
+  // Notification handling - register a callback for a given notification
+  // method (e.g. "notifications/resources/updated"). This lets applications
+  // observe server-initiated notifications such as resource updates.
+  //
+  // The handler is invoked in the dispatcher thread when a matching
+  // notification arrives. Registering a handler for a method that already has
+  // one replaces the previous handler. Mirrors the server-side
+  // registerNotificationHandler design.
+  void registerNotificationHandler(
+      const std::string& method,
+      std::function<void(const jsonrpc::Notification&)> handler);
+
   // Progress tracking - register callback for progress updates
   void trackProgress(const ProgressToken& token,
                      std::function<void(double)> callback);
@@ -605,6 +617,14 @@ class McpClient : public application::ApplicationBase {
   // Progress tracking - use string representation as map key
   std::map<std::string, std::function<void(double)>> progress_callbacks_;
   std::mutex progress_mutex_;
+
+  // Application-registered notification handlers, keyed by notification method.
+  // Guarded by a mutex because registration may happen on the application
+  // thread while dispatch (lookup) happens on the dispatcher thread. Mirrors
+  // the server's notification_handlers_/handlers_mutex_ design.
+  std::map<std::string, std::function<void(const jsonrpc::Notification&)>>
+      notification_handlers_;
+  std::mutex notification_handlers_mutex_;
 
   // Protocol state
   bool initialized_{false};

--- a/src/client/mcp_client.cc
+++ b/src/client/mcp_client.cc
@@ -827,9 +827,45 @@ void McpClient::handleRequest(const Request& request) {
   connection_manager_->sendResponse(response);
 }
 
-// Handle notifications from server
+// Register an application-level notification handler for a given method.
+// Safe to call from any thread; the handler itself is always invoked in the
+// dispatcher thread by handleNotification().
+void McpClient::registerNotificationHandler(
+    const std::string& method,
+    std::function<void(const jsonrpc::Notification&)> handler) {
+  std::lock_guard<std::mutex> lock(notification_handlers_mutex_);
+  notification_handlers_[method] = std::move(handler);
+}
+
+// Handle notifications from server.
+//
+// Invoked in the dispatcher thread via ProtocolCallbacksImpl::onNotification,
+// which is driven by the JSON-RPC protocol filter. Routes the notification to
+// the application handler registered for its method, if any. Unhandled
+// notification methods are ignored (per JSON-RPC, notifications are never
+// answered), matching the server-side onNotification behaviour.
 void McpClient::handleNotification(const Notification& notification) {
-  // Process based on method
+  std::function<void(const jsonrpc::Notification&)> handler;
+  {
+    std::lock_guard<std::mutex> lock(notification_handlers_mutex_);
+    auto it = notification_handlers_.find(notification.method);
+    if (it != notification_handlers_.end()) {
+      handler = it->second;
+    }
+  }
+
+  // Invoke outside the lock so a handler may (re)register handlers without
+  // deadlocking, and so a slow handler does not block registration.
+  if (handler) {
+    try {
+      handler(notification);
+    } catch (const std::exception&) {
+      // Notifications carry no response; swallow handler exceptions so a
+      // misbehaving callback cannot tear down the dispatcher. Count it as a
+      // client-side error for observability.
+      client_stats_.errors_total++;
+    }
+  }
 }
 
 // Handle errors

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,6 +118,9 @@ add_executable(test_mcp_client_memory client/test_mcp_client_memory.cc)
 # Connection promise fix tests
 add_executable(test_connection_promise_fix client/test_connection_promise_fix.cc)
 
+# MCP Client notification handler tests
+add_executable(test_mcp_client_notifications client/test_mcp_client_notifications.cc)
+
 # C API tests
 if(BUILD_C_API)
     # Tests using new opaque handle API
@@ -840,6 +843,18 @@ target_link_libraries(test_connection_promise_fix
     Threads::Threads
 )
 
+# MCP Client notification handler tests
+target_link_libraries(test_mcp_client_notifications
+    gopher-mcp
+    gopher-mcp-event
+    gopher-mcp-logging
+    gtest
+    gmock
+    gtest_main
+    Threads::Threads
+    fmt::fmt
+)
+
 # Link libraries for C API tests
 if(BUILD_C_API)
     # Test for new opaque handle C API types
@@ -1375,6 +1390,7 @@ add_test(NAME ConnectionManagerTest COMMAND test_connection_manager)
 add_test(NAME BuildersTest COMMAND test_builders)
 add_test(NAME McpClientThreadingTest COMMAND test_mcp_client_threading)
 add_test(NAME McpClientMemoryTest COMMAND test_mcp_client_memory)
+add_test(NAME McpClientNotificationTest COMMAND test_mcp_client_notifications)
 
 # New tests for recent fixes
 add_test(NAME ConnectionPoolCallbacksTest COMMAND test_connection_pool_callbacks)

--- a/tests/client/test_mcp_client_notifications.cc
+++ b/tests/client/test_mcp_client_notifications.cc
@@ -1,0 +1,146 @@
+/**
+ * @file test_mcp_client_notifications.cc
+ * @brief Unit tests for client-side notification handler registration.
+ *
+ * Verifies McpClient::registerNotificationHandler / handleNotification, the
+ * mechanism that lets applications observe server-initiated notifications such
+ * as resource updates (notifications/resources/updated).
+ *
+ * These tests drive handleNotification() directly (the dispatcher-thread entry
+ * point invoked by the protocol filter), so no socket or live connection is
+ * required — the dispatch logic is exercised in isolation.
+ */
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "mcp/client/mcp_client.h"
+#include "mcp/types.h"
+
+namespace mcp {
+namespace client {
+namespace {
+
+// Test peer exposing the protected dispatcher-thread entry point so the
+// dispatch logic can be exercised directly, without standing up a connection.
+// This is the same path the JSON-RPC protocol filter drives on the wire.
+class TestClient : public McpClient {
+ public:
+  using McpClient::McpClient;
+  void deliverNotification(const jsonrpc::Notification& notification) {
+    handleNotification(notification);
+  }
+};
+
+class McpClientNotificationTest : public ::testing::Test {
+ protected:
+  McpClientConfig config_;
+};
+
+// A registered handler fires for a matching notification method and receives
+// the notification (including its params) intact.
+TEST_F(McpClientNotificationTest,
+       RegisteredHandlerReceivesMatchingNotification) {
+  TestClient client(config_);
+
+  int call_count = 0;
+  std::string seen_uri;
+  client.registerNotificationHandler(
+      "notifications/resources/updated", [&](const jsonrpc::Notification& n) {
+        ++call_count;
+        ASSERT_TRUE(n.params.has_value());
+        auto it = n.params.value().find("uri");
+        ASSERT_NE(it, n.params.value().end());
+        ASSERT_TRUE(holds_alternative<std::string>(it->second));
+        seen_uri = get<std::string>(it->second);
+      });
+
+  Metadata params;
+  params["uri"] = std::string("file:///tmp/watched.txt");
+  jsonrpc::Notification notification("notifications/resources/updated", params);
+
+  client.deliverNotification(notification);
+
+  EXPECT_EQ(call_count, 1);
+  EXPECT_EQ(seen_uri, "file:///tmp/watched.txt");
+}
+
+// A notification with no registered handler is silently ignored (notifications
+// are never answered) and must not affect other handlers.
+TEST_F(McpClientNotificationTest, UnregisteredMethodIsIgnored) {
+  TestClient client(config_);
+
+  bool called = false;
+  client.registerNotificationHandler(
+      "notifications/resources/updated",
+      [&](const jsonrpc::Notification&) { called = true; });
+
+  jsonrpc::Notification other("notifications/tools/list_changed");
+  EXPECT_NO_THROW(client.deliverNotification(other));
+  EXPECT_FALSE(called);
+}
+
+// Registering a second handler for the same method replaces the first.
+TEST_F(McpClientNotificationTest, ReRegisteringReplacesHandler) {
+  TestClient client(config_);
+
+  bool first_called = false;
+  bool second_called = false;
+  client.registerNotificationHandler(
+      "notifications/resources/updated",
+      [&](const jsonrpc::Notification&) { first_called = true; });
+  client.registerNotificationHandler(
+      "notifications/resources/updated",
+      [&](const jsonrpc::Notification&) { second_called = true; });
+
+  client.deliverNotification(
+      jsonrpc::Notification("notifications/resources/updated"));
+
+  EXPECT_FALSE(first_called);
+  EXPECT_TRUE(second_called);
+}
+
+// An exception thrown by a handler is swallowed (a misbehaving callback must
+// not tear down the dispatcher) and counted as a client error.
+TEST_F(McpClientNotificationTest, HandlerExceptionIsContainedAndCounted) {
+  TestClient client(config_);
+
+  const uint64_t errors_before = client.getClientStats().errors_total;
+  client.registerNotificationHandler(
+      "notifications/resources/updated", [](const jsonrpc::Notification&) {
+        throw std::runtime_error("handler failure");
+      });
+
+  EXPECT_NO_THROW(client.deliverNotification(
+      jsonrpc::Notification("notifications/resources/updated")));
+  EXPECT_EQ(client.getClientStats().errors_total, errors_before + 1);
+}
+
+// Distinct methods route to their own handlers independently.
+TEST_F(McpClientNotificationTest, DistinctMethodsRouteIndependently) {
+  TestClient client(config_);
+
+  int updated_calls = 0;
+  int list_changed_calls = 0;
+  client.registerNotificationHandler(
+      "notifications/resources/updated",
+      [&](const jsonrpc::Notification&) { ++updated_calls; });
+  client.registerNotificationHandler(
+      "notifications/resources/list_changed",
+      [&](const jsonrpc::Notification&) { ++list_changed_calls; });
+
+  client.deliverNotification(
+      jsonrpc::Notification("notifications/resources/updated"));
+  client.deliverNotification(
+      jsonrpc::Notification("notifications/resources/list_changed"));
+  client.deliverNotification(
+      jsonrpc::Notification("notifications/resources/updated"));
+
+  EXPECT_EQ(updated_calls, 2);
+  EXPECT_EQ(list_changed_calls, 1);
+}
+
+}  // namespace
+}  // namespace client
+}  // namespace mcp


### PR DESCRIPTION
## Original ticket
https://github.com/GopherSecurity/gopher-mcp/pull/237

## Summary

`McpClient` previously dropped all server-initiated notifications: `handleNotification()` had an empty body, so applications had no way to observe events such as `notifications/resources/updated`.

This PR adds `registerNotificationHandler(method, handler)`, mirroring the existing server-side design, and wires `handleNotification()` to route each notification to the handler registered for its method.

## Details

- **Thread safety:** registration is mutex-guarded because it may run on the application thread while dispatch (lookup) runs on the dispatcher thread. The handler is copied out and invoked *outside* the lock, so a handler may (re)register handlers without deadlocking and a slow handler does not block registration.
- **Dispatcher thread:** handlers are always invoked in the dispatcher thread, consistent with the rest of the connection lifecycle.
- **Fault containment:** handler exceptions are swallowed (notifications carry no response, and a misbehaving callback must not tear down the dispatcher) and counted in `client_stats_.errors_total` for observability.
- **Unhandled methods:** notifications with no registered handler are silently ignored, per JSON-RPC.

## Tests

New `test_mcp_client_notifications` covering:
- matching dispatch (handler fires, params intact)
- unregistered-method passthrough (ignored, no effect on other handlers)
- handler replacement (re-registering same method replaces previous)
- exception containment and error counting
- independent multi-method routing

The tests drive the dispatcher-thread entry point directly, so no socket or live connection is required.