### PR TITLE
Populate ReadResourceResult contents in McpClient::readResource

### DIFF
--- a/include/mcp/types.h
+++ b/include/mcp/types.h
@@ -477,6 +477,38 @@ struct ListToolsResult {
   ListToolsResult() = default;
 };
 
+// Resource contents variations and ReadResourceResult are defined here (before
+// the jsonrpc::ResponseResult variant) so ReadResourceResult can participate in
+// that variant, mirroring ListResourcesResult / ListToolsResult above. This is
+// what lets a resources/read response deserialize into a structured result
+// rather than being flattened into Metadata.
+struct ResourceContents {
+  optional<std::string> uri;
+  optional<std::string> mimeType;
+
+  ResourceContents() = default;
+};
+
+struct TextResourceContents : ResourceContents {
+  std::string text;
+
+  TextResourceContents() = default;
+  explicit TextResourceContents(const std::string& t) : text(t) {}
+};
+
+struct BlobResourceContents : ResourceContents {
+  std::string blob;  // Base64-encoded data
+
+  BlobResourceContents() = default;
+  explicit BlobResourceContents(const std::string& b) : blob(b) {}
+};
+
+struct ReadResourceResult {
+  std::vector<variant<TextResourceContents, BlobResourceContents>> contents;
+
+  ReadResourceResult() = default;
+};
+
 // JSON-RPC message types
 namespace jsonrpc {
 
@@ -513,6 +545,7 @@ using ResponseResult = variant<std::nullptr_t,
                                std::vector<Resource>,
                                ListResourcesResult,
                                ListToolsResult,
+                               ReadResourceResult,
                                json::JsonValue>;
 
 struct Response {
@@ -594,27 +627,8 @@ inline Response make_error_response(const RequestId& id,
 
 }  // namespace jsonrpc
 
-// Resource contents variations
-struct ResourceContents {
-  optional<std::string> uri;
-  optional<std::string> mimeType;
-
-  ResourceContents() = default;
-};
-
-struct TextResourceContents : ResourceContents {
-  std::string text;
-
-  TextResourceContents() = default;
-  explicit TextResourceContents(const std::string& t) : text(t) {}
-};
-
-struct BlobResourceContents : ResourceContents {
-  std::string blob;  // Base64-encoded data
-
-  BlobResourceContents() = default;
-  explicit BlobResourceContents(const std::string& b) : blob(b) {}
-};
+// Resource contents variations (ResourceContents, TextResourceContents,
+// BlobResourceContents) are defined earlier, before the ResponseResult variant.
 
 // Factory functions for resource contents
 inline TextResourceContents make_text_resource(const std::string& text) {
@@ -944,11 +958,8 @@ struct ReadResourceRequest : jsonrpc::Request {
   }
 };
 
-struct ReadResourceResult {
-  std::vector<variant<TextResourceContents, BlobResourceContents>> contents;
-
-  ReadResourceResult() = default;
-};
+// ReadResourceResult is defined earlier, before the ResponseResult variant, so
+// it can participate in that variant (see the comment near ListToolsResult).
 
 struct ResourceListChangedNotification : jsonrpc::Notification {
   ResourceListChangedNotification() : jsonrpc::Notification() {

--- a/src/client/mcp_client.cc
+++ b/src/client/mcp_client.cc
@@ -1165,11 +1165,18 @@ std::future<ReadResourceResult> McpClient::readResource(
       if (response.error.has_value()) {
         result_promise->set_exception(std::make_exception_ptr(
             std::runtime_error(response.error->message)));
-      } else {
-        // Parse ReadResourceResult from response
+      } else if (response.result.has_value()) {
+        // The ResponseResult variant directly contains a ReadResourceResult
+        // (the deserializer recognizes the "contents" array and builds one),
+        // mirroring how listResources/listTools extract their results.
         ReadResourceResult result;
-        // TODO: Parse response into result structure
+        if (holds_alternative<ReadResourceResult>(response.result.value())) {
+          result = get<ReadResourceResult>(response.result.value());
+        }
         result_promise->set_value(result);
+      } else {
+        // No result payload at all; return an empty (but valid) result.
+        result_promise->set_value(ReadResourceResult());
       }
     } catch (...) {
       result_promise->set_exception(std::current_exception());

--- a/src/json/json_serialization.cc
+++ b/src/json/json_serialization.cc
@@ -131,6 +131,10 @@ JsonValue serialize_ResponseResult(const jsonrpc::ResponseResult& result) {
         // ListToolsResult is a full result object with tools array
         json_result = to_json(list_result);
       },
+      [&json_result](const ReadResourceResult& read_result) {
+        // ReadResourceResult is a full result object with a contents array
+        json_result = to_json(read_result);
+      },
       [&json_result](const JsonValue& json_val) {
         // Direct JsonValue passthrough for arbitrary nested JSON responses
         json_result = json_val;
@@ -539,6 +543,12 @@ jsonrpc::ResponseResult deserialize_ResponseResult(const JsonValue& json) {
     // Check if it's a ListToolsResult (has "tools" array)
     if (json.contains("tools") && json["tools"].isArray()) {
       return jsonrpc::ResponseResult(from_json<ListToolsResult>(json));
+    }
+    // Check if it's a ReadResourceResult - has a "contents" array field.
+    // Note: CallToolResult uses "content" (singular); ReadResourceResult uses
+    // "contents" (plural), so the two do not collide here.
+    if (json.contains("contents") && json["contents"].isArray()) {
+      return jsonrpc::ResponseResult(from_json<ReadResourceResult>(json));
     }
     // Otherwise treat as Metadata
     return jsonrpc::ResponseResult(jsonToMetadata(json));

--- a/tests/json/test_mcp_serialization.cc
+++ b/tests/json/test_mcp_serialization.cc
@@ -454,6 +454,72 @@ TEST_F(MCPSerializationTest, ReadResourceResult) {
   testRoundTrip(result);
 }
 
+// Regression test: a resources/read response on the wire is an object with a
+// "contents" array. The ResponseResult deserializer must recognize it and
+// produce a structured ReadResourceResult (not flatten it into Metadata), so
+// that McpClient::readResource returns populated contents instead of empty.
+TEST_F(MCPSerializationTest, ResponseResultDeserializesReadResource) {
+  // Build the wire-shaped response payload, exactly as a server emits it.
+  JsonValue text_entry = JsonValue::object();
+  text_entry["uri"] = "file:///notes.txt";
+  text_entry["mimeType"] = "text/plain";
+  text_entry["text"] = "hello world";
+
+  JsonValue blob_entry = JsonValue::object();
+  blob_entry["uri"] = "file:///image.png";
+  blob_entry["mimeType"] = "image/png";
+  blob_entry["blob"] = "YmluYXJ5";  // base64
+
+  JsonValue contents = JsonValue::array();
+  contents.push_back(std::move(text_entry));
+  contents.push_back(std::move(blob_entry));
+
+  JsonValue payload = JsonValue::object();
+  payload["contents"] = std::move(contents);
+
+  // Deserialize through the ResponseResult path (the path the client uses).
+  auto result = from_json<jsonrpc::ResponseResult>(payload);
+
+  ASSERT_TRUE(holds_alternative<ReadResourceResult>(result));
+  const auto& read_result = get<ReadResourceResult>(result);
+  ASSERT_EQ(read_result.contents.size(), 2u);
+
+  // First entry is text content with its uri/mimeType preserved.
+  ASSERT_TRUE(holds_alternative<TextResourceContents>(read_result.contents[0]));
+  const auto& text = get<TextResourceContents>(read_result.contents[0]);
+  EXPECT_EQ(text.text, "hello world");
+  ASSERT_TRUE(text.uri.has_value());
+  EXPECT_EQ(text.uri.value(), "file:///notes.txt");
+  ASSERT_TRUE(text.mimeType.has_value());
+  EXPECT_EQ(text.mimeType.value(), "text/plain");
+
+  // Second entry is blob content.
+  ASSERT_TRUE(holds_alternative<BlobResourceContents>(read_result.contents[1]));
+  const auto& blob = get<BlobResourceContents>(read_result.contents[1]);
+  EXPECT_EQ(blob.blob, "YmluYXJ5");
+  ASSERT_TRUE(blob.uri.has_value());
+  EXPECT_EQ(blob.uri.value(), "file:///image.png");
+}
+
+// A full ResponseResult round-trip through the variant: serialize a
+// ReadResourceResult-bearing result and read it back unchanged.
+TEST_F(MCPSerializationTest, ResponseResultReadResourceRoundTrip) {
+  ReadResourceResult result;
+  TextResourceContents text("file body");
+  text.uri = mcp::make_optional(std::string("file:///a.txt"));
+  result.contents.push_back(text);
+
+  jsonrpc::ResponseResult response_result(result);
+  JsonValue j = to_json(response_result);
+  auto back = from_json<jsonrpc::ResponseResult>(j);
+
+  ASSERT_TRUE(holds_alternative<ReadResourceResult>(back));
+  const auto& round = get<ReadResourceResult>(back);
+  ASSERT_EQ(round.contents.size(), 1u);
+  ASSERT_TRUE(holds_alternative<TextResourceContents>(round.contents[0]));
+  EXPECT_EQ(get<TextResourceContents>(round.contents[0]).text, "file body");
+}
+
 TEST_F(MCPSerializationTest, CallToolRequest) {
   // Simple tool call
   CallToolRequest simple_req = make_tool_call("calculator");


### PR DESCRIPTION
## Original ticket
https://github.com/GopherSecurity/gopher-mcp/issues/235

## Problem

A client calling `readResource()` always gets back an **empty** `ReadResourceResult`. The response branch of `McpClient::readResource` contained:

```cpp
// TODO: Parse response into result structure
ReadResourceResult result;
result_promise->set_value(result);
```

The TODO was only the surface. The structured result had nowhere to land:

- `ReadResourceResult` was **not** part of the `jsonrpc::ResponseResult` variant.
- `deserialize_ResponseResult` did not recognize a `resources/read` response (`{"contents": [...]}`). It fell through to `jsonToMetadata`, which flattens nested arrays into a JSON string — discarding the contents structure entirely.

## Fix

Mirrors the existing `ListResourcesResult` / `ListToolsResult` handling exactly:

1. **Types** — move `ResourceContents` / `TextResourceContents` / `BlobResourceContents` / `ReadResourceResult` above the `ResponseResult` variant (they must be complete types before the variant) and add `ReadResourceResult` as an alternative.
2. **Deserialize** — `deserialize_ResponseResult` now detects a `"contents"` array and builds a `ReadResourceResult`. `CallToolResult` uses `"content"` (singular), so there is no collision with `"contents"` (plural).
3. **Serialize** — the exhaustive `serialize_ResponseResult` visitor gains the new case.
4. **Client** — `readResource` extracts the `ReadResourceResult` from the variant instead of returning an empty value.

No wire-format change: the server already emits `{"contents": [...]}` (it serializes a `ReadResourceResult` and passes it through). This is purely a client-side parsing fix.

## Tests

Added to `test_mcp_serialization`:
- Deserialize a wire-shaped `resources/read` response into a structured `ReadResourceResult` (text + blob entries, `uri`/`mimeType` preserved).
- Full `ResponseResult` round-trip through the variant.

All existing serialization and resource-read suites pass (`test_mcp_serialization` 77, `test_mcp_serialization_extensive` 21, `test_resource_read` 9).