### PR TITLE
Surface request params._meta to server-side tool handlers

### DIFF
--- a/include/mcp/logging/logger.h
+++ b/include/mcp/logging/logger.h
@@ -38,28 +38,32 @@ class Logger : public std::enable_shared_from_this<Logger> {
   template <typename... Args>
   void debug(const char* fmt, Args&&... args) {
     if (shouldLog(LogLevel::Debug)) {
-      logImpl(LogLevel::Debug, fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...));
+      logImpl(LogLevel::Debug,
+              fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...));
     }
   }
 
   template <typename... Args>
   void info(const char* fmt, Args&&... args) {
     if (shouldLog(LogLevel::Info)) {
-      logImpl(LogLevel::Info, fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...));
+      logImpl(LogLevel::Info,
+              fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...));
     }
   }
 
   template <typename... Args>
   void warning(const char* fmt, Args&&... args) {
     if (shouldLog(LogLevel::Warning)) {
-      logImpl(LogLevel::Warning, fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...));
+      logImpl(LogLevel::Warning,
+              fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...));
     }
   }
 
   template <typename... Args>
   void error(const char* fmt, Args&&... args) {
     if (shouldLog(LogLevel::Error)) {
-      logImpl(LogLevel::Error, fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...));
+      logImpl(LogLevel::Error,
+              fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...));
     }
   }
 

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -214,6 +214,16 @@ class SessionContext {
 
   const optional<Implementation>& getClientInfo() const { return client_info_; }
 
+  // Request-scoped metadata: the in-flight request's params._meta, carried as its
+  // stringified-JSON form (consistent with how nested arguments are represented
+  // in Metadata). Set immediately before each tool handler is dispatched and
+  // cleared when the request carries no _meta, so a handler can read out-of-band
+  // correlation ids (e.g. run_id / tool_call_id) without the dispatch forking.
+  // Safe as a per-session field because request dispatch is synchronous per
+  // request on the dispatcher thread; it is overwritten on the next call.
+  void setRequestMeta(const optional<std::string>& meta) { request_meta_ = meta; }
+  const optional<std::string>& getRequestMeta() const { return request_meta_; }
+
   // Subscription management
   void addSubscription(const std::string& uri) {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -241,6 +251,7 @@ class SessionContext {
   std::chrono::steady_clock::time_point created_time_;
   std::chrono::steady_clock::time_point last_activity_;
   optional<Implementation> client_info_;
+  optional<std::string> request_meta_;  // params._meta of the in-flight request
 
   mutable std::mutex mutex_;
   std::set<std::string> subscriptions_;

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -214,14 +214,17 @@ class SessionContext {
 
   const optional<Implementation>& getClientInfo() const { return client_info_; }
 
-  // Request-scoped metadata: the in-flight request's params._meta, carried as its
-  // stringified-JSON form (consistent with how nested arguments are represented
-  // in Metadata). Set immediately before each tool handler is dispatched and
-  // cleared when the request carries no _meta, so a handler can read out-of-band
-  // correlation ids (e.g. run_id / tool_call_id) without the dispatch forking.
-  // Safe as a per-session field because request dispatch is synchronous per
-  // request on the dispatcher thread; it is overwritten on the next call.
-  void setRequestMeta(const optional<std::string>& meta) { request_meta_ = meta; }
+  // Request-scoped metadata: the in-flight request's params._meta, carried as
+  // its stringified-JSON form (consistent with how nested arguments are
+  // represented in Metadata). Set immediately before each tool handler is
+  // dispatched and cleared when the request carries no _meta, so a handler can
+  // read out-of-band correlation ids (e.g. run_id / tool_call_id) without the
+  // dispatch forking. Safe as a per-session field because request dispatch is
+  // synchronous per request on the dispatcher thread; it is overwritten on the
+  // next call.
+  void setRequestMeta(const optional<std::string>& meta) {
+    request_meta_ = meta;
+  }
   const optional<std::string>& getRequestMeta() const { return request_meta_; }
 
   // Subscription management

--- a/src/config/file_config_source.cc
+++ b/src/config/file_config_source.cc
@@ -49,9 +49,10 @@
 // Platform-specific includes
 #ifdef _WIN32
 #include <windows.h>
+
 #include <sys/stat.h>
 #ifndef S_ISDIR
-#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
 #endif
 #endif
 

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -1128,6 +1128,17 @@ jsonrpc::Response McpServer::handleCallTool(const jsonrpc::Request& request,
     }
   }
 
+  // Surface the request's params._meta (out-of-band metadata, e.g. correlation
+  // ids) to the tool handler via the session it already receives. Carried as its
+  // stringified-JSON form, like nested arguments above. Cleared when absent so a
+  // prior request's _meta never aliases this one.
+  auto meta_it = params.find("_meta");
+  if (meta_it != params.end() && holds_alternative<std::string>(meta_it->second)) {
+    session.setRequestMeta(mcp::make_optional(get<std::string>(meta_it->second)));
+  } else {
+    session.setRequestMeta(nullopt);
+  }
+
   // Call tool
   GOPHER_LOG_DEBUG("Calling tool_registry_->callTool for: {}", name);
   auto result = tool_registry_->callTool(name, arguments, session);

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -1129,12 +1129,14 @@ jsonrpc::Response McpServer::handleCallTool(const jsonrpc::Request& request,
   }
 
   // Surface the request's params._meta (out-of-band metadata, e.g. correlation
-  // ids) to the tool handler via the session it already receives. Carried as its
-  // stringified-JSON form, like nested arguments above. Cleared when absent so a
-  // prior request's _meta never aliases this one.
+  // ids) to the tool handler via the session it already receives. Carried as
+  // its stringified-JSON form, like nested arguments above. Cleared when absent
+  // so a prior request's _meta never aliases this one.
   auto meta_it = params.find("_meta");
-  if (meta_it != params.end() && holds_alternative<std::string>(meta_it->second)) {
-    session.setRequestMeta(mcp::make_optional(get<std::string>(meta_it->second)));
+  if (meta_it != params.end() &&
+      holds_alternative<std::string>(meta_it->second)) {
+    session.setRequestMeta(
+        mcp::make_optional(get<std::string>(meta_it->second)));
   } else {
     session.setRequestMeta(nullopt);
   }


### PR DESCRIPTION
## Summary

Cherry-picks two commits from `feature/session-request-meta` onto current `main`, surfacing the in-flight request's `params._meta` (out-of-band metadata such as correlation ids) to server-side tool handlers.

- `ecbaffd1` — Add a request-scoped `_meta` carrier to `SessionContext` (#236): `setRequestMeta`/`getRequestMeta` hold the in-flight request's `params._meta` in its stringified-JSON form, consistent with how nested arguments are represented in `Metadata`.
- `bdcbd10d` — Surface request `params._meta` to tool handlers (#236): `handleCallTool` stashes `params._meta` onto the session before dispatch, beside the existing arguments extraction. It is cleared when the request carries no `_meta`, so a prior request's value never aliases the current one.

## Design notes

- The value is per-request but stored on the per-session `SessionContext`. This is safe because a session dispatches one request at a time on the dispatcher thread, and `handleCallTool` sets it fresh before each dispatch.
- Tool handlers already receive the session, so no handler signature changes.

Both commits applied cleanly with no conflicts; the library builds without errors on top of current main.