### PR TITLE
Fix SSL transport data loss on full network BIO (large tools/list hang)

### DIFF
--- a/include/mcp/transport/ssl_transport_socket.h
+++ b/include/mcp/transport/ssl_transport_socket.h
@@ -263,6 +263,15 @@ class SslTransportSocket
   size_t moveFromBio();
 
   /**
+   * Write as much of `buffer` as the network BIO will currently accept,
+   * draining the bytes that were written. Any remainder the BIO could not
+   * accept is left at the front of `buffer` for the caller to preserve.
+   *
+   * @return Bytes written into the network BIO
+   */
+  size_t writeToNetworkBio(Buffer& buffer);
+
+  /**
    * Schedule handshake retry
    * Used when handshake needs I/O
    */
@@ -297,6 +306,12 @@ class SslTransportSocket
   // I/O buffers
   std::unique_ptr<Buffer> read_buffer_;   // Temporary read buffer
   std::unique_ptr<Buffer> write_buffer_;  // Temporary write buffer
+
+  // Encrypted bytes read from the socket that did not fit in the network BIO
+  // on a previous moveToBio() call. They have already been consumed from the
+  // kernel socket buffer, so they must be re-fed (in order) before reading
+  // more, otherwise the TLS byte stream is corrupted. Empty in the common case.
+  std::unique_ptr<Buffer> bio_carryover_;
 
   // Statistics
   uint64_t bytes_encrypted_{0};     // Total bytes encrypted

--- a/src/transport/ssl_transport_socket.cc
+++ b/src/transport/ssl_transport_socket.cc
@@ -215,6 +215,7 @@ SslTransportSocket::SslTransportSocket(network::TransportSocketPtr inner_socket,
   // Initialize buffers with reserve for performance
   read_buffer_ = std::make_unique<OwnedBuffer>();
   write_buffer_ = std::make_unique<OwnedBuffer>();
+  bio_carryover_ = std::make_unique<OwnedBuffer>();
 
   // Buffers will grow as needed during handshake
 
@@ -1127,8 +1128,16 @@ TransportIoResult SslTransportSocket::performOptimizedSslRead(Buffer& buffer) {
 
       switch (ssl_error) {
         case SSL_ERROR_WANT_READ:
-          // Need more data from socket
-          keep_reading = false;
+          // SSL has drained the readable BIO. Try to refill it from any
+          // carried-over bytes and/or fresh socket data. If we managed to feed
+          // more encrypted data, keep decrypting so a response larger than the
+          // BIO capacity drains fully within this read instead of stalling
+          // (and instead of stranding carried-over bytes when the socket has
+          // no further read event to trigger us again).
+          if (moveToBio() == 0) {
+            // Nothing left to feed; genuinely need more data from the socket.
+            keep_reading = false;
+          }
           break;
 
         case SSL_ERROR_ZERO_RETURN:
@@ -1234,6 +1243,55 @@ TransportIoResult SslTransportSocket::performOptimizedSslWrite(
   return TransportIoResult::success(total_bytes_written);
 }
 
+size_t SslTransportSocket::writeToNetworkBio(Buffer& buffer) {
+  /**
+   * Write as much of `buffer` as the network BIO will accept, draining the
+   * bytes that were written. The unaccepted remainder (if the BIO fills) is
+   * left at the front of `buffer` so the caller can preserve it. A memory BIO
+   * may accept a slice only partially, which also means it is now full.
+   */
+  size_t written_total = 0;
+
+  while (buffer.length() > 0) {
+    constexpr size_t max_slices = 16;
+    RawSlice slices[max_slices];
+    size_t num_slices = buffer.getRawSlices(slices, max_slices);
+
+    bool bio_full = false;
+    size_t drained_this_pass = 0;
+    for (size_t i = 0; i < num_slices; ++i) {
+      if (slices[i].len_ == 0) {
+        continue;
+      }
+      int written = BIO_write(network_bio_, slices[i].mem_, slices[i].len_);
+      if (written > 0) {
+        written_total += written;
+        drained_this_pass += static_cast<size_t>(written);
+        if (static_cast<size_t>(written) < slices[i].len_) {
+          // Partial write: the BIO is now full.
+          bio_full = true;
+          break;
+        }
+      } else {
+        // BIO_write returned <= 0: no room left.
+        bio_full = true;
+        break;
+      }
+    }
+
+    // Remove only the bytes the BIO actually accepted; the rest stays queued.
+    if (drained_this_pass > 0) {
+      buffer.drain(drained_this_pass);
+    }
+
+    if (bio_full || drained_this_pass == 0) {
+      break;
+    }
+  }
+
+  return written_total;
+}
+
 size_t SslTransportSocket::moveToBio() {
   /**
    * Move data from socket to BIO
@@ -1243,15 +1301,36 @@ size_t SslTransportSocket::moveToBio() {
    * large TLS records (up to 16KB + headers). Without looping, SSL handshakes
    * and data reads can stall waiting for data that's already in the TCP buffer.
    *
+   * Backpressure: the network BIO is a fixed-size memory buffer. When it fills
+   * before we have written everything we read, the leftover bytes MUST be
+   * preserved (in bio_carryover_) and re-fed before any further socket read.
+   * Dropping them corrupts the TLS byte stream, which truncates large
+   * responses and tears down the connection. (This was the original bug:
+   * bytes read from the socket but rejected by a full BIO were silently lost.)
+   *
    * The loop continues until:
    * - doRead() returns 0 bytes (EAGAIN/EWOULDBLOCK - socket buffer empty)
    * - doRead() returns an error
-   * - BIO_write fails (BIO buffer full)
+   * - the network BIO fills up (remainder carried over for the next call)
    */
 
   size_t total_written = 0;
   constexpr int max_iterations = 100;  // Safety limit to prevent infinite loops
   int iterations = 0;
+
+  // First, flush bytes carried over from a previous call. These were already
+  // consumed from the kernel socket buffer, so they take priority over fresh
+  // reads to keep the encrypted stream in order.
+  if (bio_carryover_->length() > 0) {
+    total_written += writeToNetworkBio(*bio_carryover_);
+    if (bio_carryover_->length() > 0) {
+      // BIO still has no room. Wait for SSL_read to drain it before pulling
+      // any more from the socket (doing so would reorder the stream).
+      GOPHER_LOG_DEBUG("moveToBio: BIO full, {} carried-over bytes still queued",
+                       bio_carryover_->length());
+      return total_written;
+    }
+  }
 
   while (iterations++ < max_iterations) {
     // Read from inner socket
@@ -1269,27 +1348,16 @@ size_t SslTransportSocket::moveToBio() {
     GOPHER_LOG_DEBUG("moveToBio: read {} bytes from socket (iteration {})",
                      bytes_read, iterations);
 
-    // Write all data to network BIO
-    constexpr size_t max_slices = 16;
-    RawSlice slices[max_slices];
-    size_t num_slices = temp_buffer.getRawSlices(slices, max_slices);
+    // Write to the network BIO; anything it cannot accept is left in
+    // temp_buffer.
+    total_written += writeToNetworkBio(temp_buffer);
 
-    bool bio_full = false;
-    for (size_t i = 0; i < num_slices; ++i) {
-      int written = BIO_write(network_bio_, slices[i].mem_, slices[i].len_);
-      if (written > 0) {
-        total_written += written;
-      } else {
-        // BIO full or error - stop writing but continue to drain socket
-        bio_full = true;
-        GOPHER_LOG_DEBUG("moveToBio: BIO_write returned {}, BIO may be full",
-                         written);
-        break;
-      }
-    }
-
-    // If BIO is full, we should stop - the SSL layer needs to consume data
-    if (bio_full) {
+    if (temp_buffer.length() > 0) {
+      // BIO is full. Preserve the unwritten remainder instead of dropping it;
+      // it will be flushed first on the next call once SSL_read frees space.
+      size_t carried = temp_buffer.length();
+      temp_buffer.move(*bio_carryover_);
+      GOPHER_LOG_DEBUG("moveToBio: BIO full, carried over {} bytes", carried);
       break;
     }
 


### PR DESCRIPTION
## Problem

`GopherAgent.createWithUrl(...)` (and any agent creation that loads tools from an HTTPS MCP server) **hangs indefinitely** — or intermittently fails with `every configured MCP server yielded zero tools` — when the server returns a large `tools/list` response.

Root cause is in the SSL transport read path, `SslTransportSocket::moveToBio()`. It reads encrypted bytes from the socket and writes them into a fixed-size network memory BIO. When the BIO fills before all the just-read bytes are written, the old code simply `break`s and **discards the unwritten remainder**:

```cpp
int written = BIO_write(network_bio_, slices[i].mem_, slices[i].len_);
if (written > 0) {
  total_written += written;
} else {
  bio_full = true;   // <-- temp_buffer (already read from the kernel) is dropped here
  break;
}
```

Those bytes were already consumed from the kernel socket buffer, so dropping them **corrupts the TLS byte stream**. The decrypted HTTP body ends up truncated (declared `Content-Length` is never reached), so `onMessageComplete` never fires, the in-flight `tools/list` request never completes, and callers that block on the result (ReActAgent immediate tool loading in `createByJson`) hang forever. Depending on timing, the same corruption instead surfaces as a parse of zero tools.

### Evidence

Captured against a real Streamable-HTTP MCP server returning an ~82 KB `tools/list`:

```
ssl_transport moveToBio: read 16384 bytes from socket (iteration 1)
ssl_transport moveToBio: read 16384 bytes from socket (iteration 2)
ssl_transport moveToBio: read  7970 bytes from socket (iteration 3)
ssl_transport moveToBio: BIO_write returned -1, BIO may be full   <-- ~40 KB read, only ~17 KB into BIO
connection_manager onConnectionEvent event=RemoteClose           <-- stream corrupted, torn down
```

`curl` (system stack) downloads the full 82362 bytes over both HTTP/1.1 and HTTP/2; only the native SSL transport truncates — confirming the bug is the client read path, not the network or server.

## Why it only reproduces on some machines

This is a timing/buffering race, which is why it looks machine-specific. The data loss happens only when a single `moveToBio()` pass pulls **more bytes out of the kernel socket buffer than the network BIO can hold** (the BIO is a fixed ~17 KB memory buffer) before `SSL_read` drains it. Whether that condition is hit depends on how the response bytes are batched as they arrive, which varies by environment:

- **Kernel socket receive buffer size** (`SO_RCVBUF` / autotuning): larger buffers accumulate more bytes before the read event fires, so a single read yields 16 KB+ bursts that overflow the BIO.
- **TCP delivery / segment coalescing and offload (LRO/GRO), MTU, proxies/VPN tunnels**: a fast, low-latency path delivers big bursts (overflow); a slower or more fragmented path trickles smaller chunks that each fit in the BIO and get drained by `SSL_read` between reads, so it never overflows.
- **CPU speed / scheduling**: shifts the race between socket fill and `SSL_read` drain.
- **Response size**: a server with a small tool list (under BIO capacity) never triggers it. The Gmail toolset (~82 KB) is large enough to overflow — so "works on another machine" can also mean it was tested against a smaller/different MCP server.

On machines where every read happens to deliver ≤ the BIO's free space before `SSL_read` drains it, no bytes are ever dropped and everything works. On machines (like the reporter's) where reads deliver bursts larger than the BIO, bytes are dropped and the stream corrupts. It reproduced reliably on the affected machine even with the VPN/zero-trust client stopped, confirming the tunnels only influence timing — they are not the cause. The fix removes the dependency entirely: no bytes are ever dropped regardless of arrival pattern, so behavior is identical across machines.

## Fix

Two coordinated changes in `SslTransportSocket`, both confined to the transport:

1. **Never drop socket bytes the BIO can't accept.** `moveToBio()` now writes via a new `writeToNetworkBio()` helper that drains only what the BIO accepted, and any remainder is preserved in a new `bio_carryover_` buffer. On the next call, carried-over bytes are re-fed **first** (before any new socket read) so the encrypted stream stays in order. Partial `BIO_write` returns are also handled (a partial write means the BIO is now full).

2. **Drain responses larger than the BIO within one read.** On `SSL_ERROR_WANT_READ`, `performOptimizedSslRead()` now re-feeds the BIO (carry-over + fresh socket data) and keeps decrypting instead of returning immediately. This prevents stalling — and prevents stranding carried-over bytes when the socket has no further read event to retrigger us.

The result: the full `tools/list` is received, `onMessageComplete` fires, and agent creation completes.

## Verification

- Builds clean on `main`.
- Applied the identical patch to the `0.1.7` release commit (what the published npm binary is built from), rebuilt `libgopher-mcp` / `libgopher-mcp-event`, and swapped them into a failing end-to-end repro:
  - **Before:** create hangs at "Creating agent…" / `Failed to create agent (zero tools)`.
  - **After:** `Agent created successfully!`, full 82 KB tool list loads, and a real query (`list gmail draft`) returns results — stable across repeated runs.

## Files changed

- `src/transport/ssl_transport_socket.cc` — `moveToBio()` rewrite, new `writeToNetworkBio()`, `WANT_READ` re-feed in `performOptimizedSslRead()`.
- `include/mcp/transport/ssl_transport_socket.h` — `writeToNetworkBio()` declaration, `bio_carryover_` member.
