### PR TITLE
Resolve SSL transport data loss on full network BIO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -583,6 +583,17 @@ if(BUILD_SHARED_LIBS)
             INSTALL_RPATH "$ORIGIN"
             BUILD_WITH_INSTALL_RPATH OFF
         )
+        if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
+           CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang)$" AND LLHTTP_FOUND)
+            # Keep bundled llhttp symbols private on Linux ELF builds. Node.js
+            # can export ABI-incompatible llhttp symbols into the process, but
+            # broad symbolic binding would also disable normal interposition for
+            # unrelated exported library functions.
+            set(LLHTTP_LOCAL_VERSION_SCRIPT
+                "${CMAKE_CURRENT_SOURCE_DIR}/cmake/gopher-mcp-llhttp-local.map")
+            set_property(TARGET gopher-mcp APPEND_STRING PROPERTY
+                LINK_FLAGS " -Wl,--version-script=${LLHTTP_LOCAL_VERSION_SCRIPT}")
+        endif()
     endif()
 else()
     # If only static is built, create alias

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,9 @@ message(STATUS "")
 option(MCP_USE_LLHTTP "Use llhttp for HTTP/1.x parsing" ON)
 
 if(MCP_USE_LLHTTP)
-    # Use Git repository approach for better compatibility with older CMake
+    # Fetch llhttp sources without configuring its upstream CMake project. The
+    # upstream project defaults to a shared library, which can re-expose llhttp
+    # symbols to the host process and defeat the private-parser build.
     FetchContent_Declare(
         llhttp
         GIT_REPOSITORY https://github.com/nodejs/llhttp.git
@@ -236,12 +238,19 @@ if(MCP_USE_LLHTTP)
     )
     
     message(STATUS "Downloading llhttp... This may take a moment depending on your connection speed.")
-    FetchContent_MakeAvailable(llhttp)
+    FetchContent_GetProperties(llhttp)
+    if(NOT llhttp_POPULATED)
+        FetchContent_Populate(llhttp)
+    endif()
     message(STATUS "llhttp download complete.")
     
-    # Build llhttp as a simple static library
-    # The release archive contains pre-generated C files
-    file(GLOB LLHTTP_SOURCES ${llhttp_SOURCE_DIR}/src/*.c)
+    # Build llhttp as an SDK-private static library from the release's
+    # pre-generated C files.
+    set(LLHTTP_SOURCES
+        ${llhttp_SOURCE_DIR}/src/api.c
+        ${llhttp_SOURCE_DIR}/src/http.c
+        ${llhttp_SOURCE_DIR}/src/llhttp.c
+    )
     
     if(NOT TARGET llhttp)
         add_library(llhttp STATIC ${LLHTTP_SOURCES})
@@ -253,6 +262,7 @@ if(MCP_USE_LLHTTP)
         # Disable warnings for third-party code
         if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
             target_compile_options(llhttp PRIVATE -w)
+            set_target_properties(llhttp PROPERTIES C_VISIBILITY_PRESET hidden)
         elseif(MSVC)
             target_compile_options(llhttp PRIVATE /W3 /WX-)
         endif()

--- a/cmake/gopher-mcp-llhttp-local.map
+++ b/cmake/gopher-mcp-llhttp-local.map
@@ -1,0 +1,4 @@
+{
+  local:
+    llhttp*;
+};

--- a/cmake/gopher-mcp-llhttp-local.map
+++ b/cmake/gopher-mcp-llhttp-local.map
@@ -1,4 +1,13 @@
 {
   local:
-    llhttp*;
+    llhttp_execute;
+    llhttp_finish;
+    llhttp_get_error_pos;
+    llhttp_get_error_reason;
+    llhttp_init;
+    llhttp_pause;
+    llhttp_reset;
+    llhttp_resume;
+    llhttp_settings_init;
+    llhttp_should_keep_alive;
 };

--- a/include/mcp/client/mcp_client.h
+++ b/include/mcp/client/mcp_client.h
@@ -567,6 +567,7 @@ class McpClient : public application::ApplicationBase {
 
   // Internal reconnection logic (must be called on dispatcher thread)
   VoidResult reconnectInternal();
+  void clearConnectionCallbacksForShutdown();
 
   // Timer-based timeout management following production patterns
   void enableRequestTimeout(std::shared_ptr<RequestContext> context);

--- a/include/mcp/filter/http_codec_filter.h
+++ b/include/mcp/filter/http_codec_filter.h
@@ -319,9 +319,13 @@ class HttpCodecFilter : public network::Filter {
    */
   void onCodecError(const std::string& error);
 
+  struct LifetimeToken {};
+
   // Components
   MessageCallbacks* message_callbacks_;
   event::Dispatcher& dispatcher_;
+  std::shared_ptr<LifetimeToken> lifetime_token_{
+      std::make_shared<LifetimeToken>()};
   bool is_server_;
   std::string client_path_{"/rpc"};       // HTTP request path for client mode
   std::string client_host_{"localhost"};  // HTTP Host header for client mode

--- a/include/mcp/filter/http_codec_filter.h
+++ b/include/mcp/filter/http_codec_filter.h
@@ -365,6 +365,7 @@ class HttpCodecFilter : public network::Filter {
   // Per-request state is stored in HttpStreamContext, not in the filter
   HttpStreamContextManager stream_manager_;
   HttpStreamContextPtr current_stream_;  // Current stream being processed
+  optional<std::string> pending_parser_error_;
 
   // Message buffering (connection-level, not per-request)
   OwnedBuffer message_buffer_;

--- a/include/mcp/filter/http_codec_filter.h
+++ b/include/mcp/filter/http_codec_filter.h
@@ -369,6 +369,7 @@ class HttpCodecFilter : public network::Filter {
 
   // Message buffering (connection-level, not per-request)
   OwnedBuffer message_buffer_;
+  optional<std::string> pending_parser_error_;
 };
 
 }  // namespace filter

--- a/include/mcp/filter/http_codec_filter.h
+++ b/include/mcp/filter/http_codec_filter.h
@@ -373,7 +373,6 @@ class HttpCodecFilter : public network::Filter {
 
   // Message buffering (connection-level, not per-request)
   OwnedBuffer message_buffer_;
-  optional<std::string> pending_parser_error_;
 };
 
 }  // namespace filter

--- a/include/mcp/filter/http_sse_filter_chain_factory.h
+++ b/include/mcp/filter/http_sse_filter_chain_factory.h
@@ -77,20 +77,19 @@ class HttpSseFilterChainFactory : public network::FilterChainFactory {
    *                 callback URL advertised on GET /sse. Leave empty to
    *                 derive the URL from the incoming Host header.
    */
-  HttpSseFilterChainFactory(event::Dispatcher& dispatcher,
-                            McpProtocolCallbacks& message_callbacks,
-                            bool is_server = true,
-                            const std::string& http_path = "/rpc",
-                            const std::string& http_host = "localhost",
-                            bool use_sse = true,
-                            const std::string& sse_path = "/sse",
-                            const std::string& rpc_path = "/mcp",
-                            const std::string& external_url = "",
-                            const std::map<std::string, std::string>&
-                                client_headers = {},
-                            const std::shared_ptr<
-                                std::map<std::string, std::string>>&
-                                client_header_source = nullptr);
+  HttpSseFilterChainFactory(
+      event::Dispatcher& dispatcher,
+      McpProtocolCallbacks& message_callbacks,
+      bool is_server = true,
+      const std::string& http_path = "/rpc",
+      const std::string& http_host = "localhost",
+      bool use_sse = true,
+      const std::string& sse_path = "/sse",
+      const std::string& rpc_path = "/mcp",
+      const std::string& external_url = "",
+      const std::map<std::string, std::string>& client_headers = {},
+      const std::shared_ptr<std::map<std::string, std::string>>&
+          client_header_source = nullptr);
 
   // Destructor defined out-of-line so the unique_ptr<SseSessionRegistry>
   // member can use the incomplete forward-declared type in this header.
@@ -192,9 +191,9 @@ class HttpSseFilterChainFactory : public network::FilterChainFactory {
   std::string http_host_;  // HTTP Host header for client mode
   std::map<std::string, std::string> client_headers_;
   std::shared_ptr<std::map<std::string, std::string>> client_header_source_;
-  bool use_sse_;           // True for SSE mode, false for Streamable HTTP
-  std::string sse_path_;   // Server-side SSE endpoint path (e.g., "/sse")
-  std::string rpc_path_;   // Server-side JSON-RPC endpoint path (e.g., "/mcp")
+  bool use_sse_;          // True for SSE mode, false for Streamable HTTP
+  std::string sse_path_;  // Server-side SSE endpoint path (e.g., "/sse")
+  std::string rpc_path_;  // Server-side JSON-RPC endpoint path (e.g., "/mcp")
   std::string external_url_;  // External URL for absolute SSE callback URLs
   mutable bool enable_metrics_ = true;  // Enable metrics by default
 

--- a/include/mcp/filter/http_sse_filter_chain_factory.h
+++ b/include/mcp/filter/http_sse_filter_chain_factory.h
@@ -77,19 +77,20 @@ class HttpSseFilterChainFactory : public network::FilterChainFactory {
    *                 callback URL advertised on GET /sse. Leave empty to
    *                 derive the URL from the incoming Host header.
    */
-  HttpSseFilterChainFactory(
-      event::Dispatcher& dispatcher,
-      McpProtocolCallbacks& message_callbacks,
-      bool is_server = true,
-      const std::string& http_path = "/rpc",
-      const std::string& http_host = "localhost",
-      bool use_sse = true,
-      const std::string& sse_path = "/sse",
-      const std::string& rpc_path = "/mcp",
-      const std::string& external_url = "",
-      const std::map<std::string, std::string>& client_headers = {},
-      const std::shared_ptr<std::map<std::string, std::string>>&
-          client_header_source = nullptr);
+  HttpSseFilterChainFactory(event::Dispatcher& dispatcher,
+                            McpProtocolCallbacks& message_callbacks,
+                            bool is_server = true,
+                            const std::string& http_path = "/rpc",
+                            const std::string& http_host = "localhost",
+                            bool use_sse = true,
+                            const std::string& sse_path = "/sse",
+                            const std::string& rpc_path = "/mcp",
+                            const std::string& external_url = "",
+                            const std::map<std::string, std::string>&
+                                client_headers = {},
+                            const std::shared_ptr<
+                                std::map<std::string, std::string>>&
+                                client_header_source = nullptr);
 
   // Destructor defined out-of-line so the unique_ptr<SseSessionRegistry>
   // member can use the incomplete forward-declared type in this header.
@@ -191,9 +192,9 @@ class HttpSseFilterChainFactory : public network::FilterChainFactory {
   std::string http_host_;  // HTTP Host header for client mode
   std::map<std::string, std::string> client_headers_;
   std::shared_ptr<std::map<std::string, std::string>> client_header_source_;
-  bool use_sse_;          // True for SSE mode, false for Streamable HTTP
-  std::string sse_path_;  // Server-side SSE endpoint path (e.g., "/sse")
-  std::string rpc_path_;  // Server-side JSON-RPC endpoint path (e.g., "/mcp")
+  bool use_sse_;           // True for SSE mode, false for Streamable HTTP
+  std::string sse_path_;   // Server-side SSE endpoint path (e.g., "/sse")
+  std::string rpc_path_;   // Server-side JSON-RPC endpoint path (e.g., "/mcp")
   std::string external_url_;  // External URL for absolute SSE callback URLs
   mutable bool enable_metrics_ = true;  // Enable metrics by default
 

--- a/include/mcp/mcp_connection_manager.h
+++ b/include/mcp/mcp_connection_manager.h
@@ -238,9 +238,8 @@ class McpConnectionManager : public McpProtocolCallbacks,
   void onError(const Error& error) override;
   void onMessageEndpoint(const std::string& endpoint) override;
   bool sendHttpPost(const std::string& json_body) override;
-  bool sendHttpPost(
-      const std::string& json_body,
-      const std::map<std::string, std::string>& http_headers);
+  bool sendHttpPost(const std::string& json_body,
+                    const std::map<std::string, std::string>& http_headers);
 
   // ListenerCallbacks interface
   void onAccept(network::ConnectionSocketPtr&& socket) override;

--- a/include/mcp/mcp_connection_manager.h
+++ b/include/mcp/mcp_connection_manager.h
@@ -238,8 +238,9 @@ class McpConnectionManager : public McpProtocolCallbacks,
   void onError(const Error& error) override;
   void onMessageEndpoint(const std::string& endpoint) override;
   bool sendHttpPost(const std::string& json_body) override;
-  bool sendHttpPost(const std::string& json_body,
-                    const std::map<std::string, std::string>& http_headers);
+  bool sendHttpPost(
+      const std::string& json_body,
+      const std::map<std::string, std::string>& http_headers);
 
   // ListenerCallbacks interface
   void onAccept(network::ConnectionSocketPtr&& socket) override;

--- a/include/mcp/mcp_connection_manager.h
+++ b/include/mcp/mcp_connection_manager.h
@@ -224,6 +224,11 @@ class McpConnectionManager : public McpProtocolCallbacks,
                                         const std::string& server_address,
                                         bool use_ssl);
 
+  /**
+   * Clear protocol callbacks before callback owner teardown.
+   */
+  void clearProtocolCallbacks() { protocol_callbacks_ = nullptr; }
+
   // McpProtocolCallbacks interface (default implementations)
   void onRequest(const jsonrpc::Request& request) override;
   void onNotification(const jsonrpc::Notification& notification) override;

--- a/src/client/mcp_client.cc
+++ b/src/client/mcp_client.cc
@@ -399,6 +399,12 @@ VoidResult McpClient::reconnectInternal() {
 }
 
 // Shutdown client
+void McpClient::clearConnectionCallbacksForShutdown() {
+  if (connection_manager_) {
+    connection_manager_->clearProtocolCallbacks();
+  }
+}
+
 void McpClient::shutdown() {
   if (shutting_down_) {
     return;
@@ -408,16 +414,18 @@ void McpClient::shutdown() {
 
   // Close connection directly without triggering state machine
   if (connection_manager_) {
+    // Break the callback ownership link synchronously. shutdown() may be called
+    // off the dispatcher thread and immediately request dispatcher exit; a
+    // posted close task is not guaranteed to run before teardown continues.
+    clearConnectionCallbacksForShutdown();
     if (main_dispatcher_ && !main_dispatcher_->isThreadSafe()) {
       // Post to dispatcher thread
       main_dispatcher_->post([this]() {
         if (connection_manager_) {
-          connection_manager_->clearProtocolCallbacks();
           connection_manager_->close();
         }
       });
     } else {
-      connection_manager_->clearProtocolCallbacks();
       connection_manager_->close();
     }
   }
@@ -437,17 +445,19 @@ void McpClient::shutdown() {
     dispatcher_thread_.join();
   }
 
-  // Clean up dispatcher after thread has exited
-  if (main_dispatcher_) {
-    delete main_dispatcher_;
-    main_dispatcher_ = nullptr;
-  }
-
-  // Clean up resources
+  // Clean up dispatcher-owned resources before destroying the dispatcher.
+  // Deferred connection teardown can still enqueue work on the dispatcher even
+  // when shutdown skipped a posted close task.
   protocol_state_machine_.reset();
   connection_manager_.reset();
   request_tracker_.reset();
   circuit_breaker_.reset();
+
+  // Clean up dispatcher after thread has exited and its owners are gone.
+  if (main_dispatcher_) {
+    delete main_dispatcher_;
+    main_dispatcher_ = nullptr;
+  }
 
   // Client resources are cleaned up above
 }

--- a/src/client/mcp_client.cc
+++ b/src/client/mcp_client.cc
@@ -813,8 +813,8 @@ void McpClient::sendRequestInternal(std::shared_ptr<RequestContext> context) {
   last_activity_time_ = std::chrono::steady_clock::now();
 
   // Send through connection manager
-  auto send_result =
-      connection_manager_->sendRequest(request, context->http_headers);
+  auto send_result = connection_manager_->sendRequest(request,
+                                                      context->http_headers);
 
   GOPHER_LOG_DEBUG("sendRequest result: is_error={}",
                    is_error<std::nullptr_t>(send_result));
@@ -1403,11 +1403,11 @@ std::future<ListToolsResult> McpClient::listTools(
                         cursor.has_value() ? cursor.value() : "<none>");
 
   // Step 1: Post to dispatcher to send the request (non-blocking)
-  main_dispatcher_->post(
-      [this, request_future_ptr, params_ptr, http_headers]() {
-        *request_future_ptr = sendRequest(
-            "tools/list", mcp::make_optional(*params_ptr), http_headers);
-      });
+  main_dispatcher_->post([this, request_future_ptr, params_ptr, http_headers]() {
+    *request_future_ptr =
+        sendRequest("tools/list", mcp::make_optional(*params_ptr),
+                    http_headers);
+  });
 
   // Step 2: Use std::thread to wait for response on a worker thread (not
   // dispatcher!)
@@ -1495,11 +1495,11 @@ std::future<CallToolResult> McpClient::callTool(
           : "<none>");
 
   // Step 1: Post to dispatcher to send the request (non-blocking)
-  main_dispatcher_->post(
-      [this, request_future_ptr, params_ptr, http_headers]() {
-        *request_future_ptr = sendRequest(
-            "tools/call", mcp::make_optional(*params_ptr), http_headers);
-      });
+  main_dispatcher_->post([this, request_future_ptr, params_ptr, http_headers]() {
+    *request_future_ptr =
+        sendRequest("tools/call", mcp::make_optional(*params_ptr),
+                    http_headers);
+  });
 
   // Step 2: Use std::thread to wait for response on a worker thread (not
   // dispatcher!)

--- a/src/client/mcp_client.cc
+++ b/src/client/mcp_client.cc
@@ -412,10 +412,12 @@ void McpClient::shutdown() {
       // Post to dispatcher thread
       main_dispatcher_->post([this]() {
         if (connection_manager_) {
+          connection_manager_->clearProtocolCallbacks();
           connection_manager_->close();
         }
       });
     } else {
+      connection_manager_->clearProtocolCallbacks();
       connection_manager_->close();
     }
   }

--- a/src/client/mcp_client.cc
+++ b/src/client/mcp_client.cc
@@ -813,8 +813,8 @@ void McpClient::sendRequestInternal(std::shared_ptr<RequestContext> context) {
   last_activity_time_ = std::chrono::steady_clock::now();
 
   // Send through connection manager
-  auto send_result = connection_manager_->sendRequest(request,
-                                                      context->http_headers);
+  auto send_result =
+      connection_manager_->sendRequest(request, context->http_headers);
 
   GOPHER_LOG_DEBUG("sendRequest result: is_error={}",
                    is_error<std::nullptr_t>(send_result));
@@ -1403,11 +1403,11 @@ std::future<ListToolsResult> McpClient::listTools(
                         cursor.has_value() ? cursor.value() : "<none>");
 
   // Step 1: Post to dispatcher to send the request (non-blocking)
-  main_dispatcher_->post([this, request_future_ptr, params_ptr, http_headers]() {
-    *request_future_ptr =
-        sendRequest("tools/list", mcp::make_optional(*params_ptr),
-                    http_headers);
-  });
+  main_dispatcher_->post(
+      [this, request_future_ptr, params_ptr, http_headers]() {
+        *request_future_ptr = sendRequest(
+            "tools/list", mcp::make_optional(*params_ptr), http_headers);
+      });
 
   // Step 2: Use std::thread to wait for response on a worker thread (not
   // dispatcher!)
@@ -1495,11 +1495,11 @@ std::future<CallToolResult> McpClient::callTool(
           : "<none>");
 
   // Step 1: Post to dispatcher to send the request (non-blocking)
-  main_dispatcher_->post([this, request_future_ptr, params_ptr, http_headers]() {
-    *request_future_ptr =
-        sendRequest("tools/call", mcp::make_optional(*params_ptr),
-                    http_headers);
-  });
+  main_dispatcher_->post(
+      [this, request_future_ptr, params_ptr, http_headers]() {
+        *request_future_ptr = sendRequest(
+            "tools/call", mcp::make_optional(*params_ptr), http_headers);
+      });
 
   // Step 2: Use std::thread to wait for response on a worker thread (not
   // dispatcher!)

--- a/src/client/mcp_client.cc
+++ b/src/client/mcp_client.cc
@@ -961,6 +961,14 @@ TransportType McpClient::negotiateTransport(const std::string& uri) {
   } else if (uri.find("ws://") == 0 || uri.find("wss://") == 0) {
     return TransportType::WebSocket;
   } else if (uri.find("http://") == 0 || uri.find("https://") == 0) {
+    if (!config_.auto_negotiate_transport) {
+      return config_.preferred_transport;
+    }
+    if (config_.preferred_transport == TransportType::StreamableHttp ||
+        config_.preferred_transport == TransportType::HttpSse) {
+      return config_.preferred_transport;
+    }
+
     // For HTTP URLs, use heuristics to determine transport type:
     // - If URL path contains "/sse" or "/events" -> use SSE transport
     // - Otherwise -> use Streamable HTTP (simpler, more common)

--- a/src/filter/http_codec_filter.cc
+++ b/src/filter/http_codec_filter.cc
@@ -25,19 +25,24 @@
 namespace mcp {
 namespace filter {
 
-bool isValidClientHeader(const std::string& name, const std::string& value) {
-  auto has_invalid_byte = [](const std::string& text) {
-    return text.find_first_of("\r\n\0", 0, 3) != std::string::npos;
-  };
-  return !name.empty() && !value.empty() && !has_invalid_byte(name) &&
-         !has_invalid_byte(value);
-}
+namespace {
+constexpr size_t kMaxHttpBodyChunkSize = 16 * 1024 * 1024;
+constexpr size_t kMaxHttpBodySize = 16 * 1024 * 1024;
 
 std::string toLowerHeaderName(std::string value) {
   std::transform(
       value.begin(), value.end(), value.begin(),
       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
   return value;
+}
+}  // namespace
+
+bool isValidClientHeader(const std::string& name, const std::string& value) {
+  auto has_invalid_byte = [](const std::string& text) {
+    return text.find_first_of("\r\n\0", 0, 3) != std::string::npos;
+  };
+  return !name.empty() && !value.empty() && !has_invalid_byte(name) &&
+         !has_invalid_byte(value);
 }
 
 bool isGeneratedClientHeader(const std::string& name) {
@@ -718,14 +723,35 @@ http::ParserCallbackResult HttpCodecFilter::ParserCallbacks::onBody(
     const char* data, size_t length) {
   GOPHER_LOG_DEBUG("ParserCallbacks::onBody - received {} bytes", length);
 
+  if (length == 0) {
+    return http::ParserCallbackResult::Success;
+  }
+
+  if (data == nullptr || length > kMaxHttpBodyChunkSize) {
+    GOPHER_LOG_ERROR("HTTP body chunk rejected: data_present={} length={} max={}",
+                     data != nullptr, length, kMaxHttpBodyChunkSize);
+    if (parent_.message_callbacks_) {
+      parent_.message_callbacks_->onError(
+          "HTTP body chunk exceeds codec limit");
+    }
+    return http::ParserCallbackResult::Error;
+  }
+
   // For client mode (receiving responses), forward body data immediately
   // This is critical for SSE streams which never complete
   if (!parent_.is_server_ && parent_.message_callbacks_) {
-    std::string body_chunk(data, length);
-    GOPHER_LOG_DEBUG(
-        "HttpCodecFilter forwarding body chunk: {}...",
-        body_chunk.substr(0, std::min(body_chunk.length(), (size_t)100)));
-    parent_.message_callbacks_->onBody(body_chunk, false);
+    try {
+      std::string body_chunk(data, length);
+      GOPHER_LOG_DEBUG(
+          "HttpCodecFilter forwarding body chunk: {}...",
+          body_chunk.substr(0, std::min(body_chunk.length(), (size_t)100)));
+      parent_.message_callbacks_->onBody(body_chunk, false);
+    } catch (const std::bad_alloc&) {
+      GOPHER_LOG_ERROR("HTTP body chunk allocation failed: length={}", length);
+      parent_.message_callbacks_->onError(
+          "HTTP body chunk allocation failed");
+      return http::ParserCallbackResult::Error;
+    }
 
     // Client response bodies are streamed to the next filter as chunks. Do not
     // retain them in current_stream_->body because SSE responses can stay open
@@ -736,9 +762,29 @@ http::ParserCallbackResult HttpCodecFilter::ParserCallbacks::onBody(
   }
 
   if (parent_.current_stream_) {
-    parent_.current_stream_->body.append(data, length);
-    GOPHER_LOG_DEBUG("ParserCallbacks::onBody - total body now {} bytes",
-                     parent_.current_stream_->body.length());
+    const size_t current_body_size = parent_.current_stream_->body.length();
+    if (current_body_size > kMaxHttpBodySize ||
+        length > kMaxHttpBodySize - current_body_size) {
+      GOPHER_LOG_ERROR(
+          "HTTP body rejected: accumulated={} incoming={} max={}",
+          current_body_size, length, kMaxHttpBodySize);
+      parent_.pending_parser_error_ = "HTTP body exceeds codec limit";
+      return http::ParserCallbackResult::Error;
+    }
+
+    try {
+      parent_.current_stream_->body.append(data, length);
+      GOPHER_LOG_DEBUG("ParserCallbacks::onBody - total body now {} bytes",
+                       parent_.current_stream_->body.length());
+    } catch (const std::bad_alloc&) {
+      GOPHER_LOG_ERROR("HTTP body accumulation allocation failed: length={}",
+                       length);
+      if (parent_.message_callbacks_) {
+        parent_.message_callbacks_->onError(
+            "HTTP body accumulation allocation failed");
+      }
+      return http::ParserCallbackResult::Error;
+    }
   }
   // Trigger body data event based on mode
   if (parent_.is_server_) {

--- a/src/filter/http_codec_filter.cc
+++ b/src/filter/http_codec_filter.cc
@@ -34,9 +34,9 @@ bool isValidClientHeader(const std::string& name, const std::string& value) {
 }
 
 std::string toLowerHeaderName(std::string value) {
-  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
-    return static_cast<char>(std::tolower(c));
-  });
+  std::transform(
+      value.begin(), value.end(), value.begin(),
+      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
   return value;
 }
 

--- a/src/filter/http_codec_filter.cc
+++ b/src/filter/http_codec_filter.cc
@@ -521,8 +521,15 @@ void HttpCodecFilter::dispatch(Buffer& data) {
 
 void HttpCodecFilter::handleParserError(const std::string& error) {
   state_machine_->handleEvent(HttpCodecEvent::ParseError);
-  if (message_callbacks_) {
-    message_callbacks_->onError(error);
+  MessageCallbacks* callbacks = message_callbacks_;
+  if (callbacks) {
+    std::weak_ptr<LifetimeToken> lifetime = lifetime_token_;
+    dispatcher_.post([lifetime, callbacks, error]() {
+      if (lifetime.expired()) {
+        return;
+      }
+      callbacks->onError(error);
+    });
   }
 }
 

--- a/src/filter/http_codec_filter.cc
+++ b/src/filter/http_codec_filter.cc
@@ -34,9 +34,9 @@ bool isValidClientHeader(const std::string& name, const std::string& value) {
 }
 
 std::string toLowerHeaderName(std::string value) {
-  std::transform(
-      value.begin(), value.end(), value.begin(),
-      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
   return value;
 }
 

--- a/src/filter/http_codec_filter.cc
+++ b/src/filter/http_codec_filter.cc
@@ -506,6 +506,13 @@ void HttpCodecFilter::dispatch(Buffer& data) {
   // Drain consumed data from buffer
   data.drain(consumed);
 
+  if (pending_parser_error_.has_value()) {
+    std::string error = std::move(pending_parser_error_.value());
+    pending_parser_error_.reset();
+    handleParserError(error);
+    return;
+  }
+
   // Check for parser errors
   if (parser_->getStatus() == http::ParserStatus::Error) {
     handleParserError(parser_->getError());
@@ -730,10 +737,7 @@ http::ParserCallbackResult HttpCodecFilter::ParserCallbacks::onBody(
   if (data == nullptr || length > kMaxHttpBodyChunkSize) {
     GOPHER_LOG_ERROR("HTTP body chunk rejected: data_present={} length={} max={}",
                      data != nullptr, length, kMaxHttpBodyChunkSize);
-    if (parent_.message_callbacks_) {
-      parent_.message_callbacks_->onError(
-          "HTTP body chunk exceeds codec limit");
-    }
+    parent_.pending_parser_error_ = "HTTP body chunk exceeds codec limit";
     return http::ParserCallbackResult::Error;
   }
 
@@ -748,8 +752,7 @@ http::ParserCallbackResult HttpCodecFilter::ParserCallbacks::onBody(
       parent_.message_callbacks_->onBody(body_chunk, false);
     } catch (const std::bad_alloc&) {
       GOPHER_LOG_ERROR("HTTP body chunk allocation failed: length={}", length);
-      parent_.message_callbacks_->onError(
-          "HTTP body chunk allocation failed");
+      parent_.pending_parser_error_ = "HTTP body chunk allocation failed";
       return http::ParserCallbackResult::Error;
     }
 
@@ -779,10 +782,8 @@ http::ParserCallbackResult HttpCodecFilter::ParserCallbacks::onBody(
     } catch (const std::bad_alloc&) {
       GOPHER_LOG_ERROR("HTTP body accumulation allocation failed: length={}",
                        length);
-      if (parent_.message_callbacks_) {
-        parent_.message_callbacks_->onError(
-            "HTTP body accumulation allocation failed");
-      }
+      parent_.pending_parser_error_ =
+          "HTTP body accumulation allocation failed";
       return http::ParserCallbackResult::Error;
     }
   }
@@ -836,7 +837,7 @@ http::ParserCallbackResult HttpCodecFilter::ParserCallbacks::onChunkComplete() {
 }
 
 void HttpCodecFilter::ParserCallbacks::onError(const std::string& error) {
-  parent_.handleParserError(error);
+  parent_.pending_parser_error_ = error;
 }
 
 // MessageEncoderImpl implementation

--- a/src/filter/http_codec_filter.cc
+++ b/src/filter/http_codec_filter.cc
@@ -776,9 +776,8 @@ http::ParserCallbackResult HttpCodecFilter::ParserCallbacks::onBody(
     const size_t current_body_size = parent_.current_stream_->body.length();
     if (current_body_size > kMaxHttpBodySize ||
         length > kMaxHttpBodySize - current_body_size) {
-      GOPHER_LOG_ERROR(
-          "HTTP body rejected: accumulated={} incoming={} max={}",
-          current_body_size, length, kMaxHttpBodySize);
+      GOPHER_LOG_ERROR("HTTP body rejected: accumulated={} incoming={} max={}",
+                       current_body_size, length, kMaxHttpBodySize);
       parent_.pending_parser_error_ = "HTTP body exceeds codec limit";
       return http::ParserCallbackResult::Error;
     }

--- a/src/filter/http_codec_filter.cc
+++ b/src/filter/http_codec_filter.cc
@@ -726,6 +726,13 @@ http::ParserCallbackResult HttpCodecFilter::ParserCallbacks::onBody(
         "HttpCodecFilter forwarding body chunk: {}...",
         body_chunk.substr(0, std::min(body_chunk.length(), (size_t)100)));
     parent_.message_callbacks_->onBody(body_chunk, false);
+
+    // Client response bodies are streamed to the next filter as chunks. Do not
+    // retain them in current_stream_->body because SSE responses can stay open
+    // indefinitely, and onMessageComplete would also forward a duplicate copy
+    // for finite responses.
+    parent_.state_machine_->handleEvent(HttpCodecEvent::ResponseBodyData);
+    return http::ParserCallbackResult::Success;
   }
 
   if (parent_.current_stream_) {

--- a/src/filter/http_codec_filter.cc
+++ b/src/filter/http_codec_filter.cc
@@ -742,8 +742,9 @@ http::ParserCallbackResult HttpCodecFilter::ParserCallbacks::onBody(
   }
 
   if (data == nullptr || length > kMaxHttpBodyChunkSize) {
-    GOPHER_LOG_ERROR("HTTP body chunk rejected: data_present={} length={} max={}",
-                     data != nullptr, length, kMaxHttpBodyChunkSize);
+    GOPHER_LOG_ERROR(
+        "HTTP body chunk rejected: data_present={} length={} max={}",
+        data != nullptr, length, kMaxHttpBodyChunkSize);
     parent_.pending_parser_error_ = "HTTP body chunk exceeds codec limit";
     return http::ParserCallbackResult::Error;
   }

--- a/src/http/http_async_client.cc
+++ b/src/http/http_async_client.cc
@@ -267,12 +267,15 @@ class HttpAsyncClient::RequestContext
   }
 
   void onBody(const std::string& data, bool end_stream) override {
-    // HttpCodecFilter in client mode emits each body chunk twice: once
-    // inline as it arrives (end_stream=false) and once again with the
-    // fully accumulated body at message-complete (end_stream=true). We
-    // only care about the final complete body, so take the end_stream
-    // delivery and overwrite whatever streamed in.
-    if (end_stream) {
+    // HttpCodecFilter streams response body chunks as they arrive and no
+    // longer retains them for a completion replay. Keep the per-request body
+    // here, where finite HttpAsyncClient responses need it, without forcing
+    // long-lived HTTP/SSE codec streams to retain unbounded data.
+    if (!end_stream) {
+      response_.body += data;
+      saw_streamed_body_ = true;
+    } else if (!saw_streamed_body_) {
+      // Compatibility with filters that still deliver a final full body.
       response_.body = data;
     }
   }
@@ -368,6 +371,7 @@ class HttpAsyncClient::RequestContext
   std::shared_ptr<filter::HttpCodecFilter> codec_filter_;
   HttpResponse response_;
   bool completed_{false};
+  bool saw_streamed_body_{false};
 };
 
 // HttpAsyncClient implementation

--- a/src/mcp_connection_manager.cc
+++ b/src/mcp_connection_manager.cc
@@ -751,13 +751,20 @@ void McpConnectionManager::close() {
 
   // Close active connection if any
   if (active_connection_) {
-    // Remove ourselves as callbacks first to prevent use-after-free
-    active_connection_->removeConnectionCallbacks(*this);
-    // Use NoFlush to avoid triggering writes during shutdown
-    // FlushWrite can cause SSL close_notify to be sent which may access
-    // resources that are being destroyed
-    active_connection_->close(network::ConnectionCloseType::NoFlush);
-    active_connection_.reset();
+    if (active_connection_->state() != network::ConnectionState::Open) {
+      dispatcher_.deferredDelete(std::move(active_connection_));
+    } else {
+      // Use NoFlush to avoid triggering writes during shutdown
+      // FlushWrite can cause SSL close_notify to be sent which may access
+      // resources that are being destroyed
+      //
+      // Do not reset active_connection_ here. Connection::close() schedules the
+      // actual close on the dispatcher, and onConnectionEvent(LocalClose) moves
+      // active_connection_ into the deferred-delete queue after close callbacks
+      // unwind. Resetting immediately destroys the transport before that posted
+      // close runs.
+      active_connection_->close(network::ConnectionCloseType::NoFlush);
+    }
   }
 
   // Stop listening if we're a server
@@ -911,7 +918,10 @@ void McpConnectionManager::onConnectionEvent(network::ConnectionEvent event) {
   GOPHER_LOG_DEBUG(
       "McpConnectionManager forwarding event to protocol_callbacks_={}",
       (protocol_callbacks_ ? "set" : "NULL"));
-  if (protocol_callbacks_) {
+  const bool server_close_event =
+      is_server_ && (event == network::ConnectionEvent::RemoteClose ||
+                     event == network::ConnectionEvent::LocalClose);
+  if (protocol_callbacks_ && !server_close_event) {
     GOPHER_LOG_DEBUG(
         "McpConnectionManager calling protocol_callbacks_->onConnectionEvent");
     protocol_callbacks_->onConnectionEvent(event);

--- a/src/transport/ssl_transport_socket.cc
+++ b/src/transport/ssl_transport_socket.cc
@@ -1003,7 +1003,6 @@ void SslTransportSocket::extractConnectionInfo() {
    * Extract comprehensive connection information
    */
 
-  // Get peer certificate
   X509* peer_cert = SSL_get_peer_certificate(ssl_);
   if (peer_cert) {
     // Extract subject

--- a/tests/client/test_mcp_client_memory.cc
+++ b/tests/client/test_mcp_client_memory.cc
@@ -37,12 +37,35 @@
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
+#include "mcp/network/socket_interface.h"
 
 namespace mcp {
 namespace client {
 namespace test {
 
 using namespace std::chrono_literals;
+
+class RecordingProtocolCallbacks : public McpProtocolCallbacks {
+ public:
+  void onRequest(const jsonrpc::Request&) override {}
+  void onNotification(const jsonrpc::Notification&) override {}
+  void onResponse(const jsonrpc::Response&) override {}
+  void onConnectionEvent(network::ConnectionEvent event) override {
+    events.push_back(event);
+  }
+  void onError(const Error&) override {}
+
+  std::vector<network::ConnectionEvent> events;
+};
+
+class TestableMcpClient : public McpClient {
+ public:
+  using McpClient::McpClient;
+
+  void setMainDispatcherForTest(event::Dispatcher* dispatcher) {
+    main_dispatcher_ = dispatcher;
+  }
+};
 
 // ============================================================================
 // Suite 1: RequestTracker Memory Tests
@@ -414,6 +437,29 @@ TEST_F(AsyncPatternMemoryTest, ClientLifetimeTokenExpiresOnShutdown) {
   client.shutdown();
 
   EXPECT_TRUE(alive.expired());
+}
+
+TEST_F(AsyncPatternMemoryTest,
+       ShutdownCallbackClearingIsSynchronous) {
+  TestableMcpClient client(McpClientConfig{});
+  auto* dispatcher = new event::LibeventDispatcher("client-shutdown-test");
+  client.setMainDispatcherForTest(dispatcher);
+
+  McpConnectionConfig config;
+  config.transport_type = TransportType::Stdio;
+  config.use_message_framing = false;
+  auto manager = std::make_unique<McpConnectionManager>(
+      *dispatcher, network::socketInterface(), config);
+
+  RecordingProtocolCallbacks callbacks;
+  manager->setProtocolCallbacks(callbacks);
+  ASSERT_EQ(&callbacks, manager->protocol_callbacks_);
+  client.connection_manager_ = std::move(manager);
+
+  client.clearConnectionCallbacksForShutdown();
+
+  EXPECT_EQ(nullptr, client.connection_manager_->protocol_callbacks_);
+  client.shutdown();
 }
 
 TEST_F(AsyncPatternMemoryTest, InitializeResponseWithoutResultFails) {

--- a/tests/client/test_mcp_client_memory.cc
+++ b/tests/client/test_mcp_client_memory.cc
@@ -439,8 +439,7 @@ TEST_F(AsyncPatternMemoryTest, ClientLifetimeTokenExpiresOnShutdown) {
   EXPECT_TRUE(alive.expired());
 }
 
-TEST_F(AsyncPatternMemoryTest,
-       ShutdownCallbackClearingIsSynchronous) {
+TEST_F(AsyncPatternMemoryTest, ShutdownCallbackClearingIsSynchronous) {
   TestableMcpClient client(McpClientConfig{});
   auto* dispatcher = new event::LibeventDispatcher("client-shutdown-test");
   client.setMainDispatcherForTest(dispatcher);

--- a/tests/client/test_streamable_http_transport.cc
+++ b/tests/client/test_streamable_http_transport.cc
@@ -13,6 +13,18 @@
 
 #include <gtest/gtest.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
+#define private public
+#define protected public
+#include "mcp/client/mcp_client.h"
+#undef protected
+#undef private
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 #include "mcp/mcp_connection_manager.h"
 
 namespace mcp {
@@ -87,6 +99,17 @@ class TransportNegotiationTest : public ::testing::Test {
   }
 };
 
+class RealTransportNegotiationTest : public ::testing::Test {
+ protected:
+  std::unique_ptr<client::McpClient> makeClient(
+      TransportType preferred_transport, bool auto_negotiate_transport = true) {
+    client::McpClientConfig config;
+    config.preferred_transport = preferred_transport;
+    config.auto_negotiate_transport = auto_negotiate_transport;
+    return std::make_unique<client::McpClient>(config);
+  }
+};
+
 /**
  * Test: URLs with /sse path should use HttpSse transport
  */
@@ -137,6 +160,46 @@ TEST_F(TransportNegotiationTest, PathMatchingIsCaseSensitive) {
   EXPECT_FALSE(urlShouldUseSse("http://localhost:8080/SSE"));
   EXPECT_FALSE(urlShouldUseSse("http://localhost:8080/EVENTS"));
   EXPECT_TRUE(urlShouldUseStreamableHttp("http://localhost:8080/SSE"));
+}
+
+TEST_F(RealTransportNegotiationTest,
+       PreferredHttpSseOverridesStreamableHttpPathHeuristic) {
+  auto client = makeClient(TransportType::HttpSse);
+
+  EXPECT_EQ(TransportType::HttpSse,
+            client->negotiateTransport("http://localhost:8080/rpc"));
+  EXPECT_EQ(TransportType::HttpSse,
+            client->negotiateTransport("https://example.com/mcp"));
+}
+
+TEST_F(RealTransportNegotiationTest,
+       PreferredStreamableHttpOverridesSsePathHeuristic) {
+  auto client = makeClient(TransportType::StreamableHttp);
+
+  EXPECT_EQ(TransportType::StreamableHttp,
+            client->negotiateTransport("http://localhost:8080/sse"));
+  EXPECT_EQ(TransportType::StreamableHttp,
+            client->negotiateTransport("https://example.com/events"));
+}
+
+TEST_F(RealTransportNegotiationTest,
+       NonHttpPreferredTransportDoesNotOverrideAutoHttpHeuristic) {
+  auto client = makeClient(TransportType::Stdio);
+
+  EXPECT_EQ(TransportType::StreamableHttp,
+            client->negotiateTransport("http://localhost:8080/rpc"));
+  EXPECT_EQ(TransportType::HttpSse,
+            client->negotiateTransport("https://example.com/events"));
+}
+
+TEST_F(RealTransportNegotiationTest,
+       DisabledAutoNegotiationUsesPreferredTransportForHttpUrls) {
+  auto client = makeClient(TransportType::Stdio, false);
+
+  EXPECT_EQ(TransportType::Stdio,
+            client->negotiateTransport("http://localhost:8080/rpc"));
+  EXPECT_EQ(TransportType::Stdio,
+            client->negotiateTransport("https://example.com/events"));
 }
 
 // =============================================================================

--- a/tests/filter/test_http_codec_filter_simple.cc
+++ b/tests/filter/test_http_codec_filter_simple.cc
@@ -248,9 +248,9 @@ TEST_F(HttpCodecFilterIntegrationTest, OversizedRequestBodyCallbackIsRejected) {
   ASSERT_EQ(filter_->parser_callbacks_->onMessageBegin(),
             http::ParserCallbackResult::Success);
 
-  EXPECT_EQ(filter_->parser_callbacks_->onBody(&kBodyByte,
-                                               kOversizedHttpBodyChunk),
-            http::ParserCallbackResult::Error);
+  EXPECT_EQ(
+      filter_->parser_callbacks_->onBody(&kBodyByte, kOversizedHttpBodyChunk),
+      http::ParserCallbackResult::Error);
 
   EXPECT_FALSE(callbacks_.body_received_);
   EXPECT_FALSE(callbacks_.message_complete_);
@@ -262,12 +262,12 @@ TEST_F(HttpCodecFilterIntegrationTest,
             http::ParserCallbackResult::Success);
 
   const std::string half_body(kMaxHttpBodySize / 2, kBodyByte);
-  ASSERT_EQ(filter_->parser_callbacks_->onBody(half_body.data(),
-                                               half_body.size()),
-            http::ParserCallbackResult::Success);
-  ASSERT_EQ(filter_->parser_callbacks_->onBody(half_body.data(),
-                                               half_body.size()),
-            http::ParserCallbackResult::Success);
+  ASSERT_EQ(
+      filter_->parser_callbacks_->onBody(half_body.data(), half_body.size()),
+      http::ParserCallbackResult::Success);
+  ASSERT_EQ(
+      filter_->parser_callbacks_->onBody(half_body.data(), half_body.size()),
+      http::ParserCallbackResult::Success);
   ASSERT_EQ(filter_->current_stream_->body.length(), kMaxHttpBodySize);
 
   EXPECT_EQ(filter_->parser_callbacks_->onBody(&kBodyByte, 1),
@@ -302,9 +302,9 @@ TEST(HttpCodecClientModeTest, OversizedResponseBodyCallbackIsRejected) {
   ASSERT_EQ(filter.parser_callbacks_->onMessageBegin(),
             http::ParserCallbackResult::Success);
 
-  EXPECT_EQ(filter.parser_callbacks_->onBody(&kBodyByte,
-                                             kOversizedHttpBodyChunk),
-            http::ParserCallbackResult::Error);
+  EXPECT_EQ(
+      filter.parser_callbacks_->onBody(&kBodyByte, kOversizedHttpBodyChunk),
+      http::ParserCallbackResult::Error);
 
   EXPECT_FALSE(callbacks.body_received_);
   EXPECT_FALSE(callbacks.message_complete_);

--- a/tests/filter/test_http_codec_filter_simple.cc
+++ b/tests/filter/test_http_codec_filter_simple.cc
@@ -307,6 +307,45 @@ TEST(HttpCodecClientModeTest, NullResponseBodyCallbackIsRejected) {
   EXPECT_FALSE(callbacks.message_complete_);
 }
 
+TEST_F(HttpCodecFilterIntegrationTest,
+       ParserCallbackErrorIsDeferredUntilDispatchUnwinds) {
+  ASSERT_EQ(filter_->parser_callbacks_->onMessageBegin(),
+            http::ParserCallbackResult::Success);
+
+  filter_->parser_callbacks_->onError("synthetic parser callback error");
+
+  ASSERT_TRUE(filter_->pending_parser_error_.has_value());
+  EXPECT_FALSE(callbacks_.error_received_);
+
+  auto request = createGetRequest("/deferred-error");
+  filter_->dispatch(request);
+  runFor(10ms);
+
+  EXPECT_FALSE(filter_->pending_parser_error_.has_value());
+  EXPECT_TRUE(callbacks_.error_received_);
+  EXPECT_EQ(callbacks_.error_message_, "synthetic parser callback error");
+}
+
+TEST_F(HttpCodecFilterIntegrationTest,
+       BodyCallbackErrorIsDeferredUntilDispatchUnwinds) {
+  ASSERT_EQ(filter_->parser_callbacks_->onMessageBegin(),
+            http::ParserCallbackResult::Success);
+
+  EXPECT_EQ(filter_->parser_callbacks_->onBody(nullptr, 1),
+            http::ParserCallbackResult::Error);
+
+  ASSERT_TRUE(filter_->pending_parser_error_.has_value());
+  EXPECT_FALSE(callbacks_.error_received_);
+
+  auto request = createGetRequest("/deferred-body-error");
+  filter_->dispatch(request);
+  runFor(10ms);
+
+  EXPECT_FALSE(filter_->pending_parser_error_.has_value());
+  EXPECT_TRUE(callbacks_.error_received_);
+  EXPECT_EQ(callbacks_.error_message_, "HTTP body chunk exceeds codec limit");
+}
+
 TEST_F(HttpCodecFilterIntegrationTest, KeepAliveConnection) {
   filter_->onNewConnection();
 

--- a/tests/filter/test_http_codec_filter_simple.cc
+++ b/tests/filter/test_http_codec_filter_simple.cc
@@ -7,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -33,6 +34,8 @@ class TestRequestCallbacks : public HttpCodecFilter::MessageCallbacks {
   void onBody(const std::string& data, bool end_stream) override {
     body_received_ = true;
     body_ = data;
+    body_chunks_.push_back(data);
+    body_end_streams_.push_back(end_stream);
     end_stream_ = end_stream;
   }
 
@@ -50,6 +53,8 @@ class TestRequestCallbacks : public HttpCodecFilter::MessageCallbacks {
   bool error_received_{false};
   std::map<std::string, std::string> headers_;
   std::string body_;
+  std::vector<std::string> body_chunks_;
+  std::vector<bool> body_end_streams_;
   std::string error_message_;
   bool keep_alive_{false};
   bool end_stream_{false};
@@ -167,6 +172,42 @@ TEST_F(HttpCodecFilterIntegrationTest, PostRequestWithBody) {
   auto content_type_it = callbacks_.headers_.find("content-type");
   EXPECT_NE(content_type_it, callbacks_.headers_.end());
   EXPECT_EQ(content_type_it->second, "application/json");
+}
+
+TEST(HttpCodecClientModeTest, ResponseBodyIsStreamedWithoutCompletionReplay) {
+  auto factory = event::createLibeventDispatcherFactory();
+  auto dispatcher = factory->createDispatcher("test");
+  dispatcher->run(event::RunType::NonBlock);
+
+  TestRequestCallbacks callbacks;
+  HttpCodecFilter filter(callbacks, *dispatcher, false /* is_server */);
+  ASSERT_EQ(filter.onNewConnection(), network::FilterStatus::Continue);
+
+  const std::string body = "event: message\ndata: one\n\n";
+  std::string response =
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Type: text/event-stream\r\n"
+      "Content-Length: " +
+      std::to_string(body.size()) +
+      "\r\n"
+      "\r\n" +
+      body;
+
+  OwnedBuffer buffer;
+  buffer.add(response);
+  EXPECT_EQ(filter.onData(buffer, false), network::FilterStatus::Continue);
+
+  auto start = std::chrono::steady_clock::now();
+  while (std::chrono::steady_clock::now() - start < 10ms) {
+    dispatcher->run(event::RunType::NonBlock);
+    std::this_thread::sleep_for(1ms);
+  }
+
+  ASSERT_TRUE(callbacks.headers_received_);
+  ASSERT_TRUE(callbacks.message_complete_);
+  ASSERT_EQ(callbacks.body_chunks_.size(), 1u);
+  EXPECT_EQ(callbacks.body_chunks_[0], body);
+  EXPECT_FALSE(callbacks.body_end_streams_[0]);
 }
 
 TEST_F(HttpCodecFilterIntegrationTest, KeepAliveConnection) {

--- a/tests/filter/test_http_codec_filter_simple.cc
+++ b/tests/filter/test_http_codec_filter_simple.cc
@@ -13,13 +13,26 @@
 
 #include "mcp/buffer.h"
 #include "mcp/event/libevent_dispatcher.h"
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
+#define private public
 #include "mcp/filter/http_codec_filter.h"
+#undef private
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 namespace mcp {
 namespace filter {
 namespace {
 
 using namespace std::chrono_literals;
+
+constexpr size_t kOversizedHttpBodyChunk = 16 * 1024 * 1024 + 1;
+constexpr size_t kMaxHttpBodySize = 16 * 1024 * 1024;
+constexpr char kBodyByte = 'x';
 
 // Simple request callbacks implementation
 class TestRequestCallbacks : public HttpCodecFilter::MessageCallbacks {
@@ -208,6 +221,90 @@ TEST(HttpCodecClientModeTest, ResponseBodyIsStreamedWithoutCompletionReplay) {
   ASSERT_EQ(callbacks.body_chunks_.size(), 1u);
   EXPECT_EQ(callbacks.body_chunks_[0], body);
   EXPECT_FALSE(callbacks.body_end_streams_[0]);
+}
+
+TEST_F(HttpCodecFilterIntegrationTest, OversizedRequestBodyCallbackIsRejected) {
+  ASSERT_EQ(filter_->parser_callbacks_->onMessageBegin(),
+            http::ParserCallbackResult::Success);
+
+  EXPECT_EQ(filter_->parser_callbacks_->onBody(&kBodyByte,
+                                               kOversizedHttpBodyChunk),
+            http::ParserCallbackResult::Error);
+
+  EXPECT_FALSE(callbacks_.body_received_);
+  EXPECT_FALSE(callbacks_.message_complete_);
+}
+
+TEST_F(HttpCodecFilterIntegrationTest,
+       RequestBodyAccumulationOverLimitIsRejected) {
+  ASSERT_EQ(filter_->parser_callbacks_->onMessageBegin(),
+            http::ParserCallbackResult::Success);
+
+  const std::string half_body(kMaxHttpBodySize / 2, kBodyByte);
+  ASSERT_EQ(filter_->parser_callbacks_->onBody(half_body.data(),
+                                               half_body.size()),
+            http::ParserCallbackResult::Success);
+  ASSERT_EQ(filter_->parser_callbacks_->onBody(half_body.data(),
+                                               half_body.size()),
+            http::ParserCallbackResult::Success);
+  ASSERT_EQ(filter_->current_stream_->body.length(), kMaxHttpBodySize);
+
+  EXPECT_EQ(filter_->parser_callbacks_->onBody(&kBodyByte, 1),
+            http::ParserCallbackResult::Error);
+
+  ASSERT_TRUE(filter_->pending_parser_error_.has_value());
+  EXPECT_EQ(filter_->pending_parser_error_.value(),
+            "HTTP body exceeds codec limit");
+  EXPECT_FALSE(callbacks_.body_received_);
+  EXPECT_FALSE(callbacks_.message_complete_);
+}
+
+TEST_F(HttpCodecFilterIntegrationTest, NullRequestBodyCallbackIsRejected) {
+  ASSERT_EQ(filter_->parser_callbacks_->onMessageBegin(),
+            http::ParserCallbackResult::Success);
+
+  EXPECT_EQ(filter_->parser_callbacks_->onBody(nullptr, 1),
+            http::ParserCallbackResult::Error);
+
+  EXPECT_FALSE(callbacks_.body_received_);
+  EXPECT_FALSE(callbacks_.message_complete_);
+}
+
+TEST(HttpCodecClientModeTest, OversizedResponseBodyCallbackIsRejected) {
+  auto factory = event::createLibeventDispatcherFactory();
+  auto dispatcher = factory->createDispatcher("test");
+  dispatcher->run(event::RunType::NonBlock);
+
+  TestRequestCallbacks callbacks;
+  HttpCodecFilter filter(callbacks, *dispatcher, false /* is_server */);
+  ASSERT_EQ(filter.onNewConnection(), network::FilterStatus::Continue);
+  ASSERT_EQ(filter.parser_callbacks_->onMessageBegin(),
+            http::ParserCallbackResult::Success);
+
+  EXPECT_EQ(filter.parser_callbacks_->onBody(&kBodyByte,
+                                             kOversizedHttpBodyChunk),
+            http::ParserCallbackResult::Error);
+
+  EXPECT_FALSE(callbacks.body_received_);
+  EXPECT_FALSE(callbacks.message_complete_);
+}
+
+TEST(HttpCodecClientModeTest, NullResponseBodyCallbackIsRejected) {
+  auto factory = event::createLibeventDispatcherFactory();
+  auto dispatcher = factory->createDispatcher("test");
+  dispatcher->run(event::RunType::NonBlock);
+
+  TestRequestCallbacks callbacks;
+  HttpCodecFilter filter(callbacks, *dispatcher, false /* is_server */);
+  ASSERT_EQ(filter.onNewConnection(), network::FilterStatus::Continue);
+  ASSERT_EQ(filter.parser_callbacks_->onMessageBegin(),
+            http::ParserCallbackResult::Success);
+
+  EXPECT_EQ(filter.parser_callbacks_->onBody(nullptr, 1),
+            http::ParserCallbackResult::Error);
+
+  EXPECT_FALSE(callbacks.body_received_);
+  EXPECT_FALSE(callbacks.message_complete_);
 }
 
 TEST_F(HttpCodecFilterIntegrationTest, KeepAliveConnection) {

--- a/tests/filter/test_http_codec_filter_simple.cc
+++ b/tests/filter/test_http_codec_filter_simple.cc
@@ -223,6 +223,27 @@ TEST(HttpCodecClientModeTest, ResponseBodyIsStreamedWithoutCompletionReplay) {
   EXPECT_FALSE(callbacks.body_end_streams_[0]);
 }
 
+TEST(HttpCodecClientModeTest, PostedParserErrorSkipsDestroyedFilter) {
+  auto factory = event::createLibeventDispatcherFactory();
+  auto dispatcher = factory->createDispatcher("test");
+  dispatcher->run(event::RunType::NonBlock);
+
+  TestRequestCallbacks callbacks;
+  {
+    auto filter =
+        std::make_unique<HttpCodecFilter>(callbacks, *dispatcher, false);
+    filter->handleParserError("synthetic parser error");
+  }
+
+  auto start = std::chrono::steady_clock::now();
+  while (std::chrono::steady_clock::now() - start < 10ms) {
+    dispatcher->run(event::RunType::NonBlock);
+    std::this_thread::sleep_for(1ms);
+  }
+
+  EXPECT_FALSE(callbacks.error_received_);
+}
+
 TEST_F(HttpCodecFilterIntegrationTest, OversizedRequestBodyCallbackIsRejected) {
   ASSERT_EQ(filter_->parser_callbacks_->onMessageBegin(),
             http::ParserCallbackResult::Success);
@@ -344,6 +365,17 @@ TEST_F(HttpCodecFilterIntegrationTest,
   EXPECT_FALSE(filter_->pending_parser_error_.has_value());
   EXPECT_TRUE(callbacks_.error_received_);
   EXPECT_EQ(callbacks_.error_message_, "HTTP body chunk exceeds codec limit");
+}
+
+TEST_F(HttpCodecFilterIntegrationTest, ParserErrorCallbackRunsFromPostedWork) {
+  filter_->handleParserError("posted parser error");
+
+  EXPECT_FALSE(callbacks_.error_received_);
+
+  runFor(10ms);
+
+  EXPECT_TRUE(callbacks_.error_received_);
+  EXPECT_EQ(callbacks_.error_message_, "posted parser error");
 }
 
 TEST_F(HttpCodecFilterIntegrationTest, KeepAliveConnection) {

--- a/tests/network/test_mcp_connection_manager.cc
+++ b/tests/network/test_mcp_connection_manager.cc
@@ -247,9 +247,11 @@ class CloseTrackingConnection : public network::Connection {
   optional<std::chrono::milliseconds> lastRoundTripTime() const override {
     return nullopt;
   }
-  void configureInitialCongestionWindow(
-      uint64_t, std::chrono::microseconds) override {}
-  optional<uint64_t> congestionWindowInBytes() const override { return nullopt; }
+  void configureInitialCongestionWindow(uint64_t,
+                                        std::chrono::microseconds) override {}
+  optional<uint64_t> congestionWindowInBytes() const override {
+    return nullopt;
+  }
   network::Socket& socket() override {
     return unreachableRef<network::Socket>();
   }

--- a/tests/network/test_mcp_connection_manager.cc
+++ b/tests/network/test_mcp_connection_manager.cc
@@ -7,8 +7,8 @@
 #include <memory>
 #include <string>
 #include <thread>
-#include <vector>
 #include <unistd.h>
+#include <vector>
 
 #include <arpa/inet.h>
 #include <gtest/gtest.h>

--- a/tests/network/test_mcp_connection_manager.cc
+++ b/tests/network/test_mcp_connection_manager.cc
@@ -1,7 +1,13 @@
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <functional>
 #include <future>
 #include <memory>
 #include <string>
 #include <thread>
+#include <vector>
 #include <unistd.h>
 
 #include <arpa/inet.h>
@@ -9,8 +15,19 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 
+#include "mcp/buffer.h"
 #include "mcp/event/event_loop.h"
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
+#define private public
 #include "mcp/mcp_connection_manager.h"
+#undef private
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#include "mcp/network/connection.h"
 #include "mcp/network/socket_impl.h"
 
 namespace mcp {
@@ -129,6 +146,169 @@ class MockMcpProtocolCallbacks : public McpProtocolCallbacks {
   Error last_error_;
 
   std::vector<network::ConnectionEvent> events_;
+};
+
+template <class T>
+T& unreachableRef() {
+  std::abort();
+}
+
+template <class T>
+const T& unreachableConstRef() {
+  std::abort();
+}
+
+class CloseTrackingConnection : public network::Connection {
+ public:
+  CloseTrackingConnection(event::Dispatcher& dispatcher,
+                          std::atomic<bool>& destroyed)
+      : dispatcher_(dispatcher), destroyed_(destroyed) {}
+
+  ~CloseTrackingConnection() override { destroyed_ = true; }
+
+  void addConnectionCallbacks(network::ConnectionCallbacks& cb) override {
+    callbacks_.push_back(&cb);
+  }
+  void removeConnectionCallbacks(network::ConnectionCallbacks& cb) override {
+    callbacks_.erase(std::remove(callbacks_.begin(), callbacks_.end(), &cb),
+                     callbacks_.end());
+  }
+  void addBytesSentCallback(network::BytesSentCb) override {}
+  void enableHalfClose(bool enabled) override { half_close_enabled_ = enabled; }
+  bool isHalfCloseEnabled() const override { return half_close_enabled_; }
+  void close(network::ConnectionCloseType type) override {
+    ++close_count_;
+    last_close_type_ = type;
+    state_ = network::ConnectionState::Closing;
+    if (raise_local_close_on_close_) {
+      for (network::ConnectionCallbacks* cb : callbacks_) {
+        cb->onEvent(network::ConnectionEvent::LocalClose);
+      }
+    }
+  }
+  void close(network::ConnectionCloseType type,
+             const std::string& details) override {
+    close(type);
+    local_close_reason_ = details;
+  }
+  network::DetectedCloseType detectedCloseType() const override {
+    return network::DetectedCloseType::Normal;
+  }
+  event::Dispatcher& dispatcher() const override { return dispatcher_; }
+  uint64_t id() const override { return 1; }
+  void hashKey(std::vector<uint8_t>&) const override {}
+  std::string nextProtocol() const override { return ""; }
+  void noDelay(bool) override {}
+  network::ReadDisableStatus readDisableWithStatus(bool disable) override {
+    read_disabled_ = disable;
+    return disable ? network::ReadDisableStatus::TransitionedToReadDisabled
+                   : network::ReadDisableStatus::TransitionedToReadEnabled;
+  }
+  void detectEarlyCloseWhenReadDisabled(bool) override {}
+  bool readEnabled() const override { return !read_disabled_; }
+  network::ConnectionInfoSetter& connectionInfoSetter() override {
+    return unreachableRef<network::ConnectionInfoSetter>();
+  }
+  const network::ConnectionInfoProvider& connectionInfoProvider()
+      const override {
+    return unreachableConstRef<network::ConnectionInfoProvider>();
+  }
+  network::ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr()
+      const override {
+    return nullptr;
+  }
+  optional<network::Connection::UnixDomainSocketPeerCredentials>
+  unixSocketPeerCredentials() const override {
+    return nullopt;
+  }
+  void setConnectionStats(const network::ConnectionStats&) override {}
+  network::SslConnectionInfoConstSharedPtr ssl() const override {
+    return nullptr;
+  }
+  std::string requestedServerName() const override { return ""; }
+  network::ConnectionState state() const override { return state_; }
+  bool connecting() const override { return false; }
+  void write(Buffer&, bool) override {}
+  void setBufferLimits(uint32_t limit) override { buffer_limit_ = limit; }
+  uint32_t bufferLimit() const override { return buffer_limit_; }
+  bool aboveHighWatermark() const override { return false; }
+  const network::SocketOptionsSharedPtr& socketOptions() const override {
+    return socket_options_;
+  }
+  stream_info::StreamInfo& streamInfo() override { return stream_info_; }
+  const stream_info::StreamInfo& streamInfo() const override {
+    return stream_info_;
+  }
+  void setDelayedCloseTimeout(std::chrono::milliseconds) override {}
+  void setIdleReadTimeout(std::chrono::milliseconds) override {}
+  std::string transportFailureReason() const override { return ""; }
+  std::string localCloseReason() const override { return local_close_reason_; }
+  bool startSecureTransport() override { return false; }
+  optional<std::chrono::milliseconds> lastRoundTripTime() const override {
+    return nullopt;
+  }
+  void configureInitialCongestionWindow(
+      uint64_t, std::chrono::microseconds) override {}
+  optional<uint64_t> congestionWindowInBytes() const override { return nullopt; }
+  network::Socket& socket() override {
+    return unreachableRef<network::Socket>();
+  }
+  const network::Socket& socket() const override {
+    return unreachableConstRef<network::Socket>();
+  }
+  network::TransportSocket& transportSocket() override {
+    return unreachableRef<network::TransportSocket>();
+  }
+  const network::TransportSocket& transportSocket() const override {
+    return unreachableConstRef<network::TransportSocket>();
+  }
+
+  Buffer& readBuffer() override { return read_buffer_; }
+  Buffer& writeBuffer() override { return write_buffer_; }
+  Buffer* currentWriteBuffer() override { return nullptr; }
+  bool currentWriteEndStream() const override { return false; }
+  bool readHalfClosed() const override { return false; }
+  bool isClosed() const override {
+    return state_ == network::ConnectionState::Closed;
+  }
+  void readDisable(bool disable) override { read_disabled_ = disable; }
+  bool readDisabled() const override { return read_disabled_; }
+
+  network::IoHandle& ioHandle() override {
+    return unreachableRef<network::IoHandle>();
+  }
+  const network::IoHandle& ioHandle() const override {
+    return unreachableConstRef<network::IoHandle>();
+  }
+  network::Connection& connection() override {
+    return static_cast<network::Connection&>(*this);
+  }
+  bool shouldDrainReadBuffer() override { return false; }
+  void setTransportSocketIsReadable() override {}
+  void raiseEvent(network::ConnectionEvent) override {}
+  void flushWriteBuffer() override {}
+
+  void setState(network::ConnectionState state) { state_ = state; }
+
+  int close_count_{0};
+  network::ConnectionCloseType last_close_type_{
+      network::ConnectionCloseType::FlushWrite};
+  bool raise_local_close_on_close_{false};
+
+ private:
+  event::Dispatcher& dispatcher_;
+  std::atomic<bool>& destroyed_;
+  std::vector<network::ConnectionCallbacks*> callbacks_;
+  OwnedBuffer read_buffer_;
+  OwnedBuffer write_buffer_;
+  stream_info::StreamInfoImpl stream_info_;
+  network::SocketOptionsSharedPtr socket_options_{
+      std::make_shared<std::vector<network::SocketOptionConstSharedPtr>>()};
+  network::ConnectionState state_{network::ConnectionState::Open};
+  bool half_close_enabled_{false};
+  bool read_disabled_{false};
+  uint32_t buffer_limit_{0};
+  std::string local_close_reason_;
 };
 
 // JsonRpcMessageFilter tests
@@ -352,8 +532,38 @@ class McpConnectionManagerTest : public ::testing::Test {
   }
 
   void TearDown() override {
+    stopDispatcherThread();
     manager_.reset();
     dispatcher_->exit();
+  }
+
+  void startDispatcherThread() {
+    if (loop_thread_.joinable()) {
+      return;
+    }
+
+    loop_thread_ =
+        std::thread([this]() { dispatcher_->run(event::RunType::Block); });
+  }
+
+  void runOnDispatcher(std::function<void()> fn) {
+    std::atomic<bool> done{false};
+    dispatcher_->post([&done, fn = std::move(fn)]() {
+      fn();
+      done = true;
+    });
+
+    for (int i = 0; i < 400 && !done.load(); ++i) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_TRUE(done.load()) << "dispatcher never ran the posted callback";
+  }
+
+  void stopDispatcherThread() {
+    if (loop_thread_.joinable()) {
+      dispatcher_->exit();
+      loop_thread_.join();
+    }
   }
 
   event::DispatcherPtr dispatcher_;
@@ -361,6 +571,7 @@ class McpConnectionManagerTest : public ::testing::Test {
   McpConnectionConfig config_;
   std::unique_ptr<McpConnectionManager> manager_;
   MockMcpProtocolCallbacks callbacks_;
+  std::thread loop_thread_;
 };
 
 TEST_F(McpConnectionManagerTest, InitialState) {
@@ -458,6 +669,87 @@ TEST_F(McpConnectionManagerTest, DISABLED_CloseConnection) {
 
   // Close
   manager_->close();
+  EXPECT_FALSE(manager_->isConnected());
+}
+
+TEST_F(McpConnectionManagerTest, CloseDefersActiveConnectionDestruction) {
+  std::atomic<bool> destroyed{false};
+  auto connection =
+      std::make_unique<CloseTrackingConnection>(*dispatcher_, destroyed);
+  auto* connection_ptr = connection.get();
+
+  manager_->active_connection_ = std::move(connection);
+  manager_->connected_ = true;
+
+  manager_->close();
+
+  EXPECT_EQ(1, connection_ptr->close_count_);
+  EXPECT_EQ(network::ConnectionCloseType::NoFlush,
+            connection_ptr->last_close_type_);
+  EXPECT_EQ(connection_ptr, manager_->active_connection_.get());
+  EXPECT_FALSE(destroyed.load());
+  EXPECT_FALSE(manager_->isConnected());
+
+  startDispatcherThread();
+  runOnDispatcher([this]() {
+    manager_->onConnectionEvent(network::ConnectionEvent::LocalClose);
+  });
+
+  EXPECT_EQ(nullptr, manager_->active_connection_.get());
+}
+
+TEST_F(McpConnectionManagerTest, CloseReleasesAlreadyClosingConnection) {
+  std::atomic<bool> destroyed{false};
+  auto connection =
+      std::make_unique<CloseTrackingConnection>(*dispatcher_, destroyed);
+  auto* connection_ptr = connection.get();
+  connection->setState(network::ConnectionState::Closing);
+
+  manager_->active_connection_ = std::move(connection);
+  manager_->connected_ = true;
+
+  startDispatcherThread();
+  runOnDispatcher([this]() { manager_->close(); });
+
+  EXPECT_EQ(0, connection_ptr->close_count_);
+  EXPECT_EQ(nullptr, manager_->active_connection_.get());
+  EXPECT_FALSE(manager_->isConnected());
+}
+
+TEST_F(McpConnectionManagerTest, CloseDoesNotForwardAfterCallbacksCleared) {
+  std::atomic<bool> destroyed{false};
+  auto connection =
+      std::make_unique<CloseTrackingConnection>(*dispatcher_, destroyed);
+  connection->raise_local_close_on_close_ = true;
+  connection->addConnectionCallbacks(*manager_);
+
+  manager_->active_connection_ = std::move(connection);
+  manager_->connected_ = true;
+  manager_->clearProtocolCallbacks();
+
+  startDispatcherThread();
+  runOnDispatcher([this]() { manager_->close(); });
+
+  EXPECT_TRUE(callbacks_.events_.empty());
+  EXPECT_EQ(nullptr, manager_->active_connection_.get());
+}
+
+TEST_F(McpConnectionManagerTest, ServerCloseDoesNotForwardLifecycleEvent) {
+  std::atomic<bool> destroyed{false};
+  auto connection =
+      std::make_unique<CloseTrackingConnection>(*dispatcher_, destroyed);
+  connection->raise_local_close_on_close_ = true;
+  connection->addConnectionCallbacks(*manager_);
+
+  manager_->is_server_ = true;
+  manager_->active_connection_ = std::move(connection);
+  manager_->connected_ = true;
+
+  startDispatcherThread();
+  runOnDispatcher([this]() { manager_->close(); });
+
+  EXPECT_TRUE(callbacks_.events_.empty());
+  EXPECT_EQ(nullptr, manager_->active_connection_.get());
   EXPECT_FALSE(manager_->isConnected());
 }
 

--- a/tests/transport/test_ssl_transport_socket.cc
+++ b/tests/transport/test_ssl_transport_socket.cc
@@ -162,6 +162,92 @@ class TestCertificateGenerator {
   }
 };
 
+class UniqueSsl {
+ public:
+  explicit UniqueSsl(SSL* ssl = nullptr) : ssl_(ssl) {}
+  ~UniqueSsl() { reset(); }
+
+  UniqueSsl(const UniqueSsl&) = delete;
+  UniqueSsl& operator=(const UniqueSsl&) = delete;
+
+  SSL* get() const { return ssl_; }
+
+  SSL* release() {
+    SSL* ssl = ssl_;
+    ssl_ = nullptr;
+    return ssl;
+  }
+
+  void reset(SSL* ssl = nullptr) {
+    if (ssl_) {
+      SSL_free(ssl_);
+    }
+    ssl_ = ssl;
+  }
+
+ private:
+  SSL* ssl_{nullptr};
+};
+
+bool completeInMemoryHandshake(SSL* client_ssl, SSL* server_ssl) {
+  BIO* client_read = nullptr;
+  BIO* client_write = nullptr;
+  BIO* server_read = nullptr;
+  BIO* server_write = nullptr;
+
+  if (BIO_new_bio_pair(&client_read, 0, &server_write, 0) != 1 ||
+      BIO_new_bio_pair(&server_read, 0, &client_write, 0) != 1) {
+    if (client_read) {
+      BIO_free(client_read);
+    }
+    if (client_write) {
+      BIO_free(client_write);
+    }
+    if (server_read) {
+      BIO_free(server_read);
+    }
+    if (server_write) {
+      BIO_free(server_write);
+    }
+    return false;
+  }
+
+  SSL_set_bio(client_ssl, client_read, client_write);
+  SSL_set_bio(server_ssl, server_read, server_write);
+  SSL_set_connect_state(client_ssl);
+  SSL_set_accept_state(server_ssl);
+
+  bool client_done = false;
+  bool server_done = false;
+  for (int i = 0; i < 100 && (!client_done || !server_done); ++i) {
+    if (!client_done) {
+      int ret = SSL_do_handshake(client_ssl);
+      if (ret == 1) {
+        client_done = true;
+      } else {
+        int err = SSL_get_error(client_ssl, ret);
+        if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
+          return false;
+        }
+      }
+    }
+
+    if (!server_done) {
+      int ret = SSL_do_handshake(server_ssl);
+      if (ret == 1) {
+        server_done = true;
+      } else {
+        int err = SSL_get_error(server_ssl, ret);
+        if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
+          return false;
+        }
+      }
+    }
+  }
+
+  return client_done && server_done;
+}
+
 // ============================================================================
 // SECTION A: UNIT TESTS WITH MOCK DISPATCHER (9 tests)
 // ============================================================================
@@ -488,6 +574,65 @@ TEST_F(SslTransportSocketUnitTest, ConnectionInfo) {
   EXPECT_EQ(ssl_socket->getCipherSuite(), "");
   EXPECT_EQ(ssl_socket->getTlsVersion(), "");
   EXPECT_TRUE(ssl_socket->getSubjectAltNames().empty());
+}
+
+TEST_F(SslTransportSocketUnitTest,
+       ExtractConnectionInfoKeepsPeerMetadataWhenVerifyPeerDisabled) {
+  auto cert = TestCertificateGenerator::generateSelfSignedCert(
+      "skip-peer-metadata.example.com");
+  ASSERT_NE(cert, nullptr);
+
+  const std::string cert_file = "/tmp/test_skip_tls_cert.pem";
+  const std::string key_file = "/tmp/test_skip_tls_key.pem";
+  {
+    std::ofstream cert_out(cert_file);
+    cert_out << cert->cert_pem;
+  }
+  {
+    std::ofstream key_out(key_file);
+    key_out << cert->key_pem;
+  }
+
+  SslContextConfig client_config;
+  client_config.is_client = true;
+  client_config.verify_peer = false;
+  auto client_context_result = SslContext::create(client_config);
+  ASSERT_FALSE(holds_alternative<Error>(client_context_result));
+  auto client_context = get<SslContextSharedPtr>(client_context_result);
+
+  SslContextConfig server_config;
+  server_config.is_client = false;
+  server_config.verify_peer = false;
+  server_config.cert_chain_file = cert_file;
+  server_config.private_key_file = key_file;
+  auto server_context_result = SslContext::create(server_config);
+  ASSERT_FALSE(holds_alternative<Error>(server_context_result));
+  auto server_context = get<SslContextSharedPtr>(server_context_result);
+
+  UniqueSsl client_ssl(client_context->newSsl());
+  UniqueSsl server_ssl(server_context->newSsl());
+  ASSERT_NE(client_ssl.get(), nullptr);
+  ASSERT_NE(server_ssl.get(), nullptr);
+  ASSERT_TRUE(completeInMemoryHandshake(client_ssl.get(), server_ssl.get()));
+
+  X509* peer_cert = SSL_get_peer_certificate(client_ssl.get());
+  ASSERT_NE(peer_cert, nullptr);
+  X509_free(peer_cert);
+
+  auto mock = std::make_unique<MockTransportSocket>();
+  auto ssl_socket = std::make_unique<SslTransportSocket>(
+      std::move(mock), client_context, SslTransportSocket::InitialRole::Client,
+      *dispatcher_);
+  ssl_socket->ssl_ = client_ssl.release();
+
+  ssl_socket->extractConnectionInfo();
+
+  EXPECT_NE(ssl_socket->peer_cert_info_.find("skip-peer-metadata.example.com"),
+            std::string::npos);
+  EXPECT_EQ(ssl_socket->subject_alt_names_.size(), 2);
+  EXPECT_EQ(ssl_socket->subject_alt_names_[0],
+            "skip-peer-metadata.example.com");
+  EXPECT_EQ(ssl_socket->subject_alt_names_[1], "*.example.com");
 }
 
 // Unit Test 4: Can Flush Close


### PR DESCRIPTION
This PR must be merged after https://github.com/GopherSecurity/gopher-mcp/pull/243

Issue:
Skip TLS peer metadata when verification is disabled (#251)
Avoid retaining streamed HTTP client bodies (#260)
Guard oversized HTTP body callbacks (#255)
Defer HTTP parser callback errors (#256)
Post HTTP parser error callbacks (#252)
Defer active connection destruction on close (#257)
Bind llhttp symbols inside shared library (#259)
Honor preferred HTTP transport (#253)