### PR TITLE
Deliver server-to-client notifications over HTTP+SSE

### DIFF
--- a/include/mcp/filter/http_sse_filter_chain_factory.h
+++ b/include/mcp/filter/http_sse_filter_chain_factory.h
@@ -173,6 +173,20 @@ class HttpSseFilterChainFactory : public network::FilterChainFactory {
   static void sendHttpResponse(const jsonrpc::Response& response,
                                network::Connection& connection);
 
+  /**
+   * Access the server-side SSE session registry, creating it on first use
+   * (same lazy construction createFilterChain performs). This is the
+   * server layer's handle for two things it cannot do from inside a
+   * request cycle:
+   *   - observing SSE stream teardown (setSessionClosedCallback), so the
+   *     MCP session keyed on the stream can be released, and
+   *   - pushing server-initiated messages (notifications) through a
+   *     client's SSE stream.
+   * Server-mode factories only; must be called on the dispatcher thread
+   * the factory was built with, like every registry operation.
+   */
+  SseSessionRegistry& sseRegistry();
+
  private:
   event::Dispatcher& dispatcher_;
   McpProtocolCallbacks& message_callbacks_;

--- a/include/mcp/filter/sse_session_registry.h
+++ b/include/mcp/filter/sse_session_registry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <string>
 
@@ -53,6 +54,17 @@ class SseSessionRegistry {
   // Drop a session. Safe to call with an unknown ID (no-op).
   void removeSession(const std::string& session_id);
 
+  // Observer for session teardown. Invoked on the dispatcher thread from
+  // removeSession() after the entry is gone, once per actually-removed
+  // session. This is how the server layer learns that a client's SSE
+  // stream — and therefore the MCP session keyed on it — has ended, so it
+  // can release session state (subscriptions etc.) that lives above the
+  // filter layer. At most one callback; setting replaces the previous one.
+  using SessionClosedCallback = std::function<void(const std::string&)>;
+  void setSessionClosedCallback(SessionClosedCallback callback) {
+    session_closed_callback_ = std::move(callback);
+  }
+
   // Write a JSON-RPC response through the SSE stream registered under
   // session_id. Returns true if the session existed and the write was
   // handed to the connection (the SSE codec filter further down the
@@ -74,6 +86,7 @@ class SseSessionRegistry {
   event::Dispatcher& dispatcher_;
   std::map<std::string, network::Connection*> sessions_;
   uint64_t next_id_{1};
+  SessionClosedCallback session_closed_callback_;
 };
 
 }  // namespace filter

--- a/include/mcp/filter/sse_session_registry.h
+++ b/include/mcp/filter/sse_session_registry.h
@@ -54,6 +54,16 @@ class SseSessionRegistry {
   // Drop a session. Safe to call with an unknown ID (no-op).
   void removeSession(const std::string& session_id);
 
+  // Drop every session streaming through the given connection. Called
+  // from the server's connection-close handler: the filter that
+  // registered the session cannot reliably do this itself because the
+  // factory keeps filters alive past their connection's death, so the
+  // filter destructor (the other removal path) may run long after the
+  // connection pointer has dangled — and a push or POST-callback routed
+  // through a stale entry is a write into freed memory. Fires the
+  // session-closed callback for each removed session, like removeSession.
+  void removeConnection(network::Connection* connection);
+
   // Observer for session teardown. Invoked on the dispatcher thread from
   // removeSession() after the entry is gone, once per actually-removed
   // session. This is how the server layer learns that a client's SSE

--- a/include/mcp/mcp_connection_manager.h
+++ b/include/mcp/mcp_connection_manager.h
@@ -180,6 +180,25 @@ class McpConnectionManager : public McpProtocolCallbacks,
     protocol_callbacks_ = &callbacks;
   }
 
+  /**
+   * Resolve a possibly-relative SSE callback endpoint against the server
+   * address the connection was configured with.
+   *
+   * The SSE "endpoint" event may carry a relative callback URL — the server
+   * announces "callback/{id}" unless an operator configured an external
+   * URL — but sendHttpPost() requires an absolute URL. Relative forms
+   * resolve to the same scheme and host:port the SSE stream itself uses,
+   * with the path made absolute. Already-absolute endpoints pass through
+   * untouched, as does everything when server_address is empty (there is
+   * nothing to resolve against; sendHttpPost will report the bad URL).
+   *
+   * Static so the resolution rules are unit-testable without a live
+   * connection.
+   */
+  static std::string resolveEndpointUrl(const std::string& endpoint,
+                                        const std::string& server_address,
+                                        bool use_ssl);
+
   // McpProtocolCallbacks interface (default implementations)
   void onRequest(const jsonrpc::Request& request) override;
   void onNotification(const jsonrpc::Notification& notification) override;

--- a/include/mcp/mcp_connection_manager.h
+++ b/include/mcp/mcp_connection_manager.h
@@ -94,6 +94,26 @@ class McpProtocolCallbacks {
   }
 
   /**
+   * Called immediately before a parsed message is dispatched, carrying the
+   * transport-level session id the message belongs to. For HTTP+SSE servers
+   * this is the SSE stream id extracted from the POST /callback/{id} path —
+   * the durable client identity that outlives the one-shot POST connection
+   * the message physically arrived on. Empty when the transport has no
+   * session concept (stdio, plain HTTP); receivers must then fall back to
+   * connection identity.
+   *
+   * Always invoked in the dispatcher thread right before the matching
+   * onRequest/onNotification/onResponse for the same message, so an
+   * implementation may stash it as request-scoped context without locking.
+   * It is re-announced per message (not per connection) because reads from
+   * different connections interleave on the dispatcher thread.
+   */
+  virtual void onTransportSessionBound(
+      const std::string& transport_session_id) {
+    (void)transport_session_id;  // Default implementation does nothing
+  }
+
+  /**
    * Send a POST request to the message endpoint
    * Used by HTTP/SSE transport to send messages on a separate connection
    * Returns true if the POST was initiated successfully

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -911,6 +911,16 @@ class McpServer : public application::ApplicationBase,
   void onConnectionEvent(network::ConnectionEvent event);
   void onError(const Error& error) override;
 
+  // Request-scoped transport session binding. The transport filter announces
+  // the transport-level session id (e.g. SSE stream id from the POST
+  // /callback/{id} path) immediately before dispatching each message, on the
+  // dispatcher thread. Stored like current_connection_ as dispatch context;
+  // an empty id means the current message's transport has no session concept
+  // and session lookup falls back to connection identity.
+  void onTransportSessionBound(const std::string& transport_session_id) {
+    current_transport_session_id_ = transport_session_id;
+  }
+
   // Request tracking helpers
   bool isRequestCancelled(const RequestId& id) const {
     std::lock_guard<std::mutex> lock(pending_requests_mutex_);
@@ -931,6 +941,13 @@ class McpServer : public application::ApplicationBase,
  private:
   // Register built-in handlers
   void registerBuiltinHandlers();
+
+  // Resolve the session for the message currently being dispatched.
+  // Prefers the transport session id (durable across the short-lived POST
+  // connections of HTTP+SSE) and falls back to connection identity for
+  // transports without one (stdio, plain HTTP). Returns nullptr only when
+  // the session limit is reached. Dispatcher thread only.
+  SessionManager::SessionPtr getOrCreateCurrentSession();
 
   // Internal method to perform actual listening (called from dispatcher thread)
   void performListen();
@@ -1027,6 +1044,11 @@ class McpServer : public application::ApplicationBase,
 
     void onError(const Error& error) override { server_.onError(error); }
 
+    void onTransportSessionBound(
+        const std::string& transport_session_id) override {
+      server_.onTransportSessionBound(transport_session_id);
+    }
+
    private:
     McpServer& server_;
   };
@@ -1045,6 +1067,13 @@ class McpServer : public application::ApplicationBase,
   // IMPROVEMENT: Using TcpActiveListener for robust listener management
   // Following production architecture for better connection lifecycle handling
   std::vector<std::unique_ptr<network::TcpActiveListener>> tcp_listeners_;
+
+  // Server-side HTTP+SSE filter chain factory (default listener path).
+  // Held here — not just dropped into the listener config — because the
+  // server needs its SSE session registry outside any request cycle: to
+  // push server-initiated notifications through a client's SSE stream and
+  // to observe stream teardown so the MCP session keyed on it is released.
+  std::shared_ptr<filter::HttpSseFilterChainFactory> http_sse_factory_;
 
   // Pending listener configurations (for config-driven startup)
   std::vector<mcp::config::ListenerConfig> pending_listener_configs_;
@@ -1067,6 +1096,11 @@ class McpServer : public application::ApplicationBase,
   // Current connection being processed (for request context)
   // This is set temporarily during request processing in dispatcher thread
   network::Connection* current_connection_{nullptr};
+
+  // Transport session id of the message currently being dispatched (see
+  // onTransportSessionBound). Dispatcher thread only, like
+  // current_connection_. Empty for transports without session identity.
+  std::string current_transport_session_id_;
 
   // Active connections owned by server
   // Following production pattern: all operations in dispatcher thread, no mutex

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -758,6 +758,18 @@ class SessionManager {
     cleanupExpiredSessionsLocked();
   }
 
+  // Enumerate active sessions (snapshot). Used by broadcast paths, which
+  // must not hold the session mutex while writing to connections.
+  std::vector<SessionPtr> getAllSessions() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<SessionPtr> result;
+    result.reserve(sessions_.size());
+    for (const auto& pair : sessions_) {
+      result.push_back(pair.second);
+    }
+    return result;
+  }
+
  private:
   // Expiry sweep body shared by the public entry point and the
   // at-capacity path inside createSession / getOrCreateSessionByTransportId,
@@ -948,6 +960,13 @@ class McpServer : public application::ApplicationBase,
   // transports without one (stdio, plain HTTP). Returns nullptr only when
   // the session limit is reached. Dispatcher thread only.
   SessionManager::SessionPtr getOrCreateCurrentSession();
+
+  // Deliver a notification to one session's client, routed by how the
+  // session is keyed: SSE stream (via the registry), owning connection,
+  // or the stdio connection manager. Dispatcher thread only.
+  VoidResult sendNotificationToSession(
+      const SessionManager::SessionPtr& session,
+      const jsonrpc::Notification& notification);
 
   // Internal method to perform actual listening (called from dispatcher thread)
   void performListen();

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -263,7 +263,7 @@ class SessionContext {
 
  private:
   SessionId id_;
-  network::Connection* connection_;  // Store raw pointer
+  network::Connection* connection_;   // Store raw pointer
   std::string transport_session_id_;  // Durable transport identity, may be ""
   std::chrono::steady_clock::time_point created_time_;
   std::chrono::steady_clock::time_point last_activity_;

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -424,29 +424,15 @@ class ResourceManager {
     }
   }
 
-  // Notify subscribers of resource update
-  void notifyResourceUpdate(const std::string& uri) {
+  // Sessions currently subscribed to a URI (snapshot). The server builds
+  // and routes the notifications/resources/updated messages from this;
+  // the manager only owns the bookkeeping. This replaces a pending-updates
+  // queue that nothing ever drained — updates were counted as sent but
+  // silently accumulated forever.
+  std::set<std::string> getSubscribers(const std::string& uri) const {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = subscriptions_.find(uri);
-    if (it != subscriptions_.end()) {
-      // Queue update notifications for subscribers
-      for (const auto& session_id : it->second) {
-        pending_updates_[session_id].insert(uri);
-      }
-      stats_.resource_updates_sent++;
-    }
-  }
-
-  // Get pending updates for session
-  std::set<std::string> getPendingUpdates(const std::string& session_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto it = pending_updates_.find(session_id);
-    if (it != pending_updates_.end()) {
-      auto updates = it->second;
-      pending_updates_.erase(it);
-      return updates;
-    }
-    return {};
+    return it != subscriptions_.end() ? it->second : std::set<std::string>{};
   }
 
  private:
@@ -456,8 +442,6 @@ class ResourceManager {
   std::vector<ResourceTemplate> resource_templates_;
   std::map<std::string, std::set<std::string>>
       subscriptions_;  // uri -> session_ids
-  std::map<std::string, std::set<std::string>>
-      pending_updates_;  // session_id -> uris
   McpServerStats& stats_;
 };
 
@@ -881,9 +865,11 @@ class McpServer : public application::ApplicationBase,
     resource_manager_->registerResourceTemplate(template_);
   }
 
-  void notifyResourceUpdate(const std::string& uri) {
-    resource_manager_->notifyResourceUpdate(uri);
-  }
+  // Push notifications/resources/updated to every session subscribed to
+  // the URI. Callable from any thread; delivery happens on the dispatcher
+  // thread through each session's own channel (SSE stream, connection, or
+  // stdio manager).
+  void notifyResourceUpdate(const std::string& uri);
 
   // Tool management
   void registerTool(const Tool& tool,

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -198,6 +198,19 @@ class SessionContext {
   const SessionId& getId() const { return id_; }
   network::Connection* getConnection() const { return connection_; }
 
+  // Transport-level session id (e.g. the SSE stream id for HTTP+SSE
+  // clients). Non-empty only for sessions keyed on a transport session
+  // rather than a connection: those clients send each request on a
+  // short-lived POST connection, so the connection pointer cannot serve
+  // as the durable identity — this id can, and it is also what the
+  // server-push path uses to find the client's SSE stream.
+  void setTransportSessionId(const std::string& transport_session_id) {
+    transport_session_id_ = transport_session_id;
+  }
+  const std::string& getTransportSessionId() const {
+    return transport_session_id_;
+  }
+
   // Update activity timestamp
   void updateActivity() { last_activity_ = std::chrono::steady_clock::now(); }
 
@@ -251,6 +264,7 @@ class SessionContext {
  private:
   SessionId id_;
   network::Connection* connection_;  // Store raw pointer
+  std::string transport_session_id_;  // Durable transport identity, may be ""
   std::chrono::steady_clock::time_point created_time_;
   std::chrono::steady_clock::time_point last_activity_;
   optional<Implementation> client_info_;
@@ -612,6 +626,69 @@ class SessionManager {
     return nullptr;
   }
 
+  // Get-or-create a session keyed on a transport-level session id (e.g.
+  // the SSE stream id). Used for transports where each request arrives on
+  // a fresh short-lived connection: the connection pointer changes per
+  // request, so keying on it would give every request its own session and
+  // lose state such as resource subscriptions. The session is deliberately
+  // created with a null connection — it must NOT be tracked in
+  // connection_sessions_, or the close of whichever POST connection it was
+  // first seen on would tear it down. Its lifetime is bounded by the
+  // transport session instead (removeSessionByTransportId on SSE stream
+  // close) plus the usual expiry sweep.
+  SessionPtr getOrCreateSessionByTransportId(
+      const std::string& transport_session_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = transport_sessions_.find(transport_session_id);
+    if (it != transport_sessions_.end()) {
+      it->second->updateActivity();
+      return it->second;
+    }
+
+    if (sessions_.size() >= config_.max_sessions) {
+      cleanupExpiredSessionsLocked();
+      if (sessions_.size() >= config_.max_sessions) {
+        return nullptr;  // Max sessions reached
+      }
+    }
+
+    auto session =
+        std::make_shared<SessionContext>(generateSessionId(), nullptr);
+    session->setTransportSessionId(transport_session_id);
+    sessions_[session->getId()] = session;
+    transport_sessions_[transport_session_id] = session;
+
+    stats_.sessions_total++;
+    stats_.sessions_active++;
+    return session;
+  }
+
+  // Get session by transport-level session id (no creation).
+  SessionPtr getSessionByTransportId(const std::string& transport_session_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = transport_sessions_.find(transport_session_id);
+    return (it != transport_sessions_.end()) ? it->second : nullptr;
+  }
+
+  // Remove the session bound to a transport-level session id. Called when
+  // the transport session ends (e.g. the client's SSE stream closes).
+  // Returns the removed session so the caller can release related state
+  // (e.g. resource subscriptions) that lives outside this manager.
+  SessionPtr removeSessionByTransportId(
+      const std::string& transport_session_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = transport_sessions_.find(transport_session_id);
+    if (it == transport_sessions_.end()) {
+      return nullptr;
+    }
+    auto session = it->second;
+    transport_sessions_.erase(it);
+    sessions_.erase(session->getId());
+    stats_.sessions_active--;
+    return session;
+  }
+
   // Remove session
   void removeSession(const std::string& session_id) {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -620,6 +697,9 @@ class SessionManager {
       // Remove from connection map if tracked
       if (it->second->getConnection()) {
         connection_sessions_.erase(it->second->getConnection());
+      }
+      if (!it->second->getTransportSessionId().empty()) {
+        transport_sessions_.erase(it->second->getTransportSessionId());
       }
       sessions_.erase(it);
       stats_.sessions_active--;
@@ -659,8 +739,8 @@ class SessionManager {
 
  private:
   // Expiry sweep body shared by the public entry point and the
-  // at-capacity path inside createSession, which already holds mutex_
-  // (non-recursive).
+  // at-capacity path inside createSession / getOrCreateSessionByTransportId,
+  // which already hold mutex_ (non-recursive).
   void cleanupExpiredSessionsLocked() {
     std::vector<std::string> expired;
 
@@ -677,6 +757,9 @@ class SessionManager {
         if (it->second->getConnection()) {
           connection_sessions_.erase(it->second->getConnection());
         }
+        if (!it->second->getTransportSessionId().empty()) {
+          transport_sessions_.erase(it->second->getTransportSessionId());
+        }
         sessions_.erase(it);
         stats_.sessions_expired++;
         stats_.sessions_active--;
@@ -692,6 +775,10 @@ class SessionManager {
   mutable std::mutex mutex_;
   std::map<std::string, SessionPtr> sessions_;
   std::unordered_map<network::Connection*, SessionPtr> connection_sessions_;
+  // Transport session id -> session, for transports whose requests arrive
+  // on short-lived connections (HTTP+SSE POST callbacks). Kept consistent
+  // with sessions_ by every mutation path above.
+  std::map<std::string, SessionPtr> transport_sessions_;
   McpServerConfig config_;
   McpServerStats& stats_;
 };

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -572,10 +572,12 @@ class SessionManager {
   SessionPtr createSession(network::Connection* connection) {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    // Check max sessions limit
+    // Check max sessions limit. Use the Locked variant — mutex_ is already
+    // held here and is not recursive, so calling the public
+    // cleanupExpiredSessions() would self-deadlock.
     if (sessions_.size() >= config_.max_sessions) {
       // Try to clean up expired sessions first
-      cleanupExpiredSessions();
+      cleanupExpiredSessionsLocked();
       if (sessions_.size() >= config_.max_sessions) {
         return nullptr;  // Max sessions reached
       }
@@ -652,6 +654,14 @@ class SessionManager {
   // Clean up expired sessions
   void cleanupExpiredSessions() {
     std::lock_guard<std::mutex> lock(mutex_);
+    cleanupExpiredSessionsLocked();
+  }
+
+ private:
+  // Expiry sweep body shared by the public entry point and the
+  // at-capacity path inside createSession, which already holds mutex_
+  // (non-recursive).
+  void cleanupExpiredSessionsLocked() {
     std::vector<std::string> expired;
 
     for (const auto& pair : sessions_) {
@@ -673,8 +683,6 @@ class SessionManager {
       }
     }
   }
-
- private:
   // Generate unique session ID
   std::string generateSessionId() {
     static std::atomic<uint64_t> counter{0};

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -407,6 +407,23 @@ class ResourceManager {
     session.removeSubscription(uri);
   }
 
+  // Drop every subscription a session holds. Called when the session ends
+  // (connection closed, SSE stream torn down, expiry) so updates for its
+  // URIs stop being fanned out to an id that can no longer receive them.
+  void releaseSession(SessionContext& session) {
+    auto uris = session.getSubscriptions();
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto& uri : uris) {
+      auto it = subscriptions_.find(uri);
+      if (it != subscriptions_.end()) {
+        it->second.erase(session.getId());
+        if (it->second.empty()) {
+          subscriptions_.erase(it);
+        }
+      }
+    }
+  }
+
   // Notify subscribers of resource update
   void notifyResourceUpdate(const std::string& uri) {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -706,19 +723,23 @@ class SessionManager {
     }
   }
 
-  // Remove session by connection
-  void removeSessionByConnection(network::Connection* connection) {
+  // Remove session by connection. Returns the removed session (or null)
+  // so the caller can release related state, mirroring
+  // removeSessionByTransportId.
+  SessionPtr removeSessionByConnection(network::Connection* connection) {
     if (!connection)
-      return;
+      return nullptr;
 
     std::lock_guard<std::mutex> lock(mutex_);
     auto conn_it = connection_sessions_.find(connection);
-    if (conn_it != connection_sessions_.end()) {
-      auto session = conn_it->second;
-      connection_sessions_.erase(conn_it);
-      sessions_.erase(session->getId());
-      stats_.sessions_active--;
+    if (conn_it == connection_sessions_.end()) {
+      return nullptr;
     }
+    auto session = conn_it->second;
+    connection_sessions_.erase(conn_it);
+    sessions_.erase(session->getId());
+    stats_.sessions_active--;
+    return session;
   }
 
   // Get session by connection

--- a/src/c_api/mcp_c_api_server.cc
+++ b/src/c_api/mcp_c_api_server.cc
@@ -115,12 +115,11 @@ mcp_error_t mcp_server_send_notification(mcp_server_t* server,
     return MCP_ERROR_INVALID_ARGUMENT;
   }
 
-  try {
-    // TODO: Send notification to connection or broadcast
-    return MCP_SUCCESS;
-  } catch (...) {
-    return MCP_ERROR_INTERNAL;
-  }
+  // This C server facade is not implemented yet (mcp_server_create never
+  // builds an underlying server, so there is nothing to send through).
+  // Report that honestly instead of returning MCP_SUCCESS while dropping
+  // the notification — callers were left believing delivery happened.
+  return MCP_ERROR_NOT_IMPLEMENTED;
 }
 
 }  // extern "C"

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -932,10 +932,19 @@ class HttpSseJsonRpcProtocolFilter
    */
   void onRequest(const jsonrpc::Request& request) override {
     GOPHER_LOG_DEBUG("HttpSseFilter::onRequest for method: {}", request.method);
+    // Announce which transport session this message belongs to before
+    // dispatching. On a POST /callback/{id} connection this carries the SSE
+    // stream id — the durable client identity — so the server can key its
+    // MCP session on it instead of this short-lived POST connection. It is
+    // announced per message (not per connection) because dispatcher-thread
+    // reads from different connections interleave; an empty id explicitly
+    // clears any previous connection's binding.
+    mcp_callbacks_.onTransportSessionBound(sse_callback_session_id_);
     mcp_callbacks_.onRequest(request);
   }
 
   void onNotification(const jsonrpc::Notification& notification) override {
+    mcp_callbacks_.onTransportSessionBound(sse_callback_session_id_);
     mcp_callbacks_.onNotification(notification);
 
     // For HTTP transport, send HTTP 202 Accepted response
@@ -961,6 +970,7 @@ class HttpSseJsonRpcProtocolFilter
   }
 
   void onResponse(const jsonrpc::Response& response) override {
+    mcp_callbacks_.onTransportSessionBound(sse_callback_session_id_);
     mcp_callbacks_.onResponse(response);
   }
 

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -1259,6 +1259,16 @@ HttpSseFilterChainFactory::HttpSseFilterChainFactory(
 // can see the complete type from this translation unit.
 HttpSseFilterChainFactory::~HttpSseFilterChainFactory() = default;
 
+SseSessionRegistry& HttpSseFilterChainFactory::sseRegistry() {
+  assert(is_server_ && "sseRegistry() is only meaningful in server mode");
+  // Same lazy construction as createFilterChain, so whichever runs first
+  // wins and both hand out the one instance.
+  if (!sse_registry_) {
+    sse_registry_.reset(new SseSessionRegistry(dispatcher_));
+  }
+  return *sse_registry_;
+}
+
 bool HttpSseFilterChainFactory::createFilterChain(
     network::FilterManager& filter_manager) const {
   // Following production pattern: create filters in order

--- a/src/filter/sse_session_registry.cc
+++ b/src/filter/sse_session_registry.cc
@@ -28,6 +28,11 @@ void SseSessionRegistry::removeSession(const std::string& session_id) {
   if (sessions_.erase(session_id) > 0) {
     GOPHER_LOG_INFO("SSE session removed: {} (total={})", session_id,
                     sessions_.size());
+    // Notify after the entry is gone so the observer cannot route a
+    // message into the half-closed stream by calling back into us.
+    if (session_closed_callback_) {
+      session_closed_callback_(session_id);
+    }
   }
 }
 

--- a/src/filter/sse_session_registry.cc
+++ b/src/filter/sse_session_registry.cc
@@ -36,6 +36,29 @@ void SseSessionRegistry::removeSession(const std::string& session_id) {
   }
 }
 
+void SseSessionRegistry::removeConnection(network::Connection* connection) {
+  assert(dispatcher_.isThreadSafe() &&
+         "SseSessionRegistry::removeConnection off-dispatcher-thread");
+  if (!connection) {
+    return;
+  }
+  for (auto it = sessions_.begin(); it != sessions_.end();) {
+    if (it->second == connection) {
+      const std::string session_id = it->first;
+      it = sessions_.erase(it);
+      GOPHER_LOG_INFO("SSE session removed on connection close: {} (total={})",
+                      session_id, sessions_.size());
+      // Erase before notifying so the observer cannot route a message
+      // into the closing stream by calling back into us.
+      if (session_closed_callback_) {
+        session_closed_callback_(session_id);
+      }
+    } else {
+      ++it;
+    }
+  }
+}
+
 bool SseSessionRegistry::sendResponse(const std::string& session_id,
                                       const std::string& json_data) {
   assert(dispatcher_.isThreadSafe() &&

--- a/src/mcp_connection_manager.cc
+++ b/src/mcp_connection_manager.cc
@@ -904,15 +904,46 @@ void McpConnectionManager::onError(const Error& error) {
   }
 }
 
+std::string McpConnectionManager::resolveEndpointUrl(
+    const std::string& endpoint,
+    const std::string& server_address,
+    bool use_ssl) {
+  if (endpoint.find("://") != std::string::npos) {
+    return endpoint;  // Already absolute.
+  }
+  if (server_address.empty()) {
+    return endpoint;  // Nothing to resolve against.
+  }
+  std::string path = endpoint;
+  if (path.empty() || path[0] != '/') {
+    path = "/" + path;
+  }
+  return (use_ssl ? "https://" : "http://") + server_address + path;
+}
+
 void McpConnectionManager::onMessageEndpoint(const std::string& endpoint) {
   GOPHER_LOG_DEBUG("McpConnectionManager::onMessageEndpoint endpoint={}",
                    endpoint);
-  message_endpoint_ = endpoint;
+  // The server announces a relative callback URL unless an external URL is
+  // configured; sendHttpPost needs an absolute one. Resolve against the
+  // same server the SSE stream is connected to.
+  std::string server_address;
+  bool use_ssl = false;
+  if (config_.http_sse_config.has_value()) {
+    server_address = config_.http_sse_config->server_address;
+    use_ssl = config_.http_sse_config->ssl_config.has_value();
+  }
+  message_endpoint_ = resolveEndpointUrl(endpoint, server_address, use_ssl);
+  if (message_endpoint_ != endpoint) {
+    GOPHER_LOG_DEBUG("Resolved relative endpoint '{}' to '{}'", endpoint,
+                     message_endpoint_);
+  }
   has_message_endpoint_ = true;
 
-  // Forward to protocol callbacks if set
+  // Forward to protocol callbacks if set. Forward the resolved form so
+  // upper layers never see a relative URL they cannot POST to.
   if (protocol_callbacks_ && protocol_callbacks_ != this) {
-    protocol_callbacks_->onMessageEndpoint(endpoint);
+    protocol_callbacks_->onMessageEndpoint(message_endpoint_);
   }
 }
 

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -992,6 +992,17 @@ void McpServer::onConnectionLifecycleEvent(network::Connection* connection,
 
   server_stats_.connections_active--;
 
+  // If the closing connection carried an SSE stream, drop its registry
+  // entry NOW — the entry holds a raw Connection* and this is the last
+  // moment it is guaranteed valid (the filter destructor, the other
+  // removal path, can run long after because the factory keeps filters
+  // alive). A stale entry would make the next push a write into freed
+  // memory. Removal fires the registry's session-closed callback, which
+  // releases the MCP session keyed on the stream and its subscriptions.
+  if (http_sse_factory_) {
+    http_sse_factory_->sseRegistry().removeConnection(connection);
+  }
+
   // Tear down session state keyed by the actual closing connection, not a
   // global current_connection_ which may point at a different session.
   // Transport-keyed sessions (HTTP+SSE) are untouched here by design: they

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -6,6 +6,8 @@
 
 #include "mcp/server/mcp_server.h"
 
+#include "mcp/filter/sse_session_registry.h"
+
 #include <algorithm>
 #include <cassert>
 #include <future>
@@ -251,6 +253,30 @@ void McpServer::performListen() {
           GOPHER_LOG_DEBUG(
               "Set route registration callback for custom endpoints");
         }
+
+        // Keep a handle on the factory: its SSE session registry is the
+        // server's only route to a client's SSE stream outside a request
+        // cycle (server-initiated notifications), and the teardown observer
+        // below is what bounds the lifetime of transport-keyed sessions.
+        http_sse_factory_ = http_sse_factory;
+
+        // When a client's SSE stream closes, drop the MCP session keyed on
+        // it and release its resource subscriptions — after this the
+        // transport identity can never carry another message, so keeping
+        // the session would only leak subscription state and let a later
+        // stream accidentally inherit it if the registry reused the id.
+        // Runs on the dispatcher thread (registry contract).
+        http_sse_factory->sseRegistry().setSessionClosedCallback(
+            [this](const std::string& transport_session_id) {
+              auto session = session_manager_->removeSessionByTransportId(
+                  transport_session_id);
+              if (session) {
+                resource_manager_->releaseSession(*session);
+                GOPHER_LOG_DEBUG(
+                    "Session {} released on SSE stream close (transport={})",
+                    session->getId(), transport_session_id);
+              }
+            });
 
         tcp_config.filter_chain_factory = http_sse_factory;
 
@@ -561,6 +587,28 @@ void McpServer::setupFilterChain(application::FilterChainBuilder& builder) {
   }
 }
 
+SessionManager::SessionPtr McpServer::getOrCreateCurrentSession() {
+  // Transport session id wins: for HTTP+SSE each request arrives on a
+  // one-shot POST connection, so keying the session on the connection
+  // would hand every request a fresh session and silently drop state
+  // such as resource subscriptions. The SSE stream id announced by the
+  // transport filter is the identity that actually spans the client's
+  // requests — and it is also what the push path needs to find the
+  // client's SSE stream.
+  if (!current_transport_session_id_.empty()) {
+    return session_manager_->getOrCreateSessionByTransportId(
+        current_transport_session_id_);
+  }
+
+  // Connection-keyed fallback for transports where the connection is
+  // long-lived (stdio) or there is no transport session concept.
+  auto session = session_manager_->getSessionByConnection(current_connection_);
+  if (!session) {
+    session = session_manager_->createSession(current_connection_);
+  }
+  return session;
+}
+
 // McpProtocolCallbacks overrides
 void McpServer::onRequest(const jsonrpc::Request& request) {
   GOPHER_LOG_DEBUG("McpServer::onRequest called with method: {}",
@@ -583,13 +631,10 @@ void McpServer::onRequest(const jsonrpc::Request& request) {
     pending_requests_[key] = pending_req;
   }
 
-  // Get or create session for this connection
-  // Try to get existing session first
-  auto session = session_manager_->getSessionByConnection(current_connection_);
-  if (!session) {
-    // Create new session for this connection
-    session = session_manager_->createSession(current_connection_);
-  }
+  // Resolve the session for this request: transport session id first
+  // (durable across HTTP+SSE POST connections), connection identity as
+  // fallback.
+  auto session = getOrCreateCurrentSession();
 
   if (session) {
     pending_req->session_id = session->getId();
@@ -722,12 +767,9 @@ void McpServer::onNotification(const jsonrpc::Notification& notification) {
   // Handle notification in dispatcher context
   server_stats_.notifications_total++;
 
-  // Get session for this connection
-  auto session = session_manager_->getSessionByConnection(current_connection_);
-  if (!session) {
-    // Create new session for notifications if needed
-    session = session_manager_->createSession(current_connection_);
-  }
+  // Resolve the session the same way requests do, so a notification sent
+  // on a fresh POST connection still lands in the subscriber's session.
+  auto session = getOrCreateCurrentSession();
   if (!session) {
     return;  // Can't process notification without session
   }

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -473,6 +473,57 @@ void McpServer::registerNotificationHandler(
   notification_handlers_[method] = handler;
 }
 
+// Deliver a notification to one session's client. Dispatcher thread only —
+// every route below writes to a connection owned by that thread.
+VoidResult McpServer::sendNotificationToSession(
+    const SessionManager::SessionPtr& session,
+    const jsonrpc::Notification& notification) {
+  assert(main_dispatcher_ && main_dispatcher_->isThreadSafe() &&
+         "sendNotificationToSession off dispatcher");
+
+  // HTTP+SSE: the session is keyed on the client's SSE stream — route the
+  // JSON through the registry, which writes it down the stream connection's
+  // filter chain (the SSE codec frames it as a `data:` event). This is the
+  // only channel that reaches an HTTP+SSE client outside a request cycle.
+  if (!session->getTransportSessionId().empty()) {
+    if (http_sse_factory_) {
+      auto json_val = json::to_json(notification);
+      if (http_sse_factory_->sseRegistry().sendResponse(
+              session->getTransportSessionId(), json_val.toString())) {
+        return makeVoidSuccess();
+      }
+    }
+    // Stream already gone (client disconnected between lookup and send) or
+    // no HTTP factory — report failure so the caller doesn't assume
+    // delivery.
+    return makeVoidError(
+        Error(jsonrpc::INTERNAL_ERROR,
+              "SSE stream gone for session " + session->getId()));
+  }
+
+  // Connection-keyed session (long-lived connection): write the JSON like
+  // the response path does and let the connection's filter chain frame it.
+  if (session->getConnection()) {
+    auto json_val = json::to_json(notification);
+    std::string json_str = json_val.toString();
+    OwnedBuffer buffer;
+    buffer.add(json_str);
+    session->getConnection()->write(buffer, false);
+    return makeVoidSuccess();
+  }
+
+  // Stdio: requests are dispatched without a connection pointer, so the
+  // session carries neither key. There is a single stdio client, reached
+  // through its connection manager.
+  for (auto& conn_manager : connection_managers_) {
+    if (conn_manager->isConnected()) {
+      return conn_manager->sendNotification(notification);
+    }
+  }
+  return makeVoidError(
+      Error(jsonrpc::INTERNAL_ERROR, "No active connection for session"));
+}
+
 // Send notification to specific session
 VoidResult McpServer::sendNotification(
     const std::string& session_id, const jsonrpc::Notification& notification) {
@@ -482,38 +533,61 @@ VoidResult McpServer::sendNotification(
     return makeVoidError(Error(jsonrpc::INVALID_PARAMS, "Session not found"));
   }
 
-  // Send notification through session's connection
-  // This needs to be done in dispatcher context
+  // Already on the dispatcher thread (e.g. called from a tool or request
+  // handler): deliver inline. The old post-and-wait here deadlocked the
+  // event loop — the future could only be fulfilled by the very thread
+  // that was blocked on it.
+  if (main_dispatcher_->isThreadSafe()) {
+    return sendNotificationToSession(session, notification);
+  }
+
+  // Off-thread caller (application thread): hop to the dispatcher and wait
+  // for the result. Safe because the dispatcher is free to run the task.
   auto send_promise = std::make_shared<std::promise<VoidResult>>();
   auto send_future = send_promise->get_future();
-
   main_dispatcher_->post([this, session, notification, send_promise]() {
-    // Find the connection manager for this session's connection
-    for (auto& conn_manager : connection_managers_) {
-      if (conn_manager->isConnected()) {
-        auto result = conn_manager->sendNotification(notification);
-        send_promise->set_value(result);
-        return;
-      }
-    }
-    send_promise->set_value(makeVoidError(
-        Error(jsonrpc::INTERNAL_ERROR, "No active connection for session")));
+    send_promise->set_value(sendNotificationToSession(session, notification));
   });
-
   return send_future.get();
 }
 
 // Broadcast notification to all sessions
 void McpServer::broadcastNotification(
     const jsonrpc::Notification& notification) {
-  // Send to all active sessions in dispatcher context
-  main_dispatcher_->post([this, notification]() {
+  // Same threading rule as sendNotification: inline when already on the
+  // dispatcher thread, hop otherwise (fire-and-forget — broadcast has no
+  // per-recipient result to report).
+  if (!main_dispatcher_->isThreadSafe()) {
+    main_dispatcher_->post(
+        [this, notification]() { broadcastNotification(notification); });
+    return;
+  }
+
+  // Route per session so HTTP+SSE clients get their copy through their own
+  // SSE stream. Sessions with neither key share the single stdio client —
+  // send through the connection managers once, not once per session.
+  bool used_manager_fallback = false;
+  for (auto& session : session_manager_->getAllSessions()) {
+    const bool needs_manager_fallback =
+        session->getTransportSessionId().empty() && !session->getConnection();
+    if (needs_manager_fallback) {
+      if (used_manager_fallback) {
+        continue;
+      }
+      used_manager_fallback = true;
+    }
+    sendNotificationToSession(session, notification);
+  }
+
+  // A stdio client that has not sent a request yet has no session at all;
+  // preserve the old behavior of still broadcasting through the managers.
+  if (!used_manager_fallback) {
     for (auto& conn_manager : connection_managers_) {
       if (conn_manager->isConnected()) {
         conn_manager->sendNotification(notification);
       }
     }
-  });
+  }
 }
 
 // ApplicationBase overrides

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -838,8 +838,15 @@ void McpServer::onConnectionLifecycleEvent(network::Connection* connection,
 
   // Tear down session state keyed by the actual closing connection, not a
   // global current_connection_ which may point at a different session.
+  // Transport-keyed sessions (HTTP+SSE) are untouched here by design: they
+  // are created with a null connection, live across many short POST
+  // connections, and are released by the SSE registry's session-closed
+  // callback when their stream ends.
   if (session_manager_) {
-    session_manager_->removeSessionByConnection(connection);
+    auto session = session_manager_->removeSessionByConnection(connection);
+    if (session && resource_manager_) {
+      resource_manager_->releaseSession(*session);
+    }
   }
   {
     std::lock_guard<std::mutex> lock(connection_sessions_mutex_);

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -6,8 +6,6 @@
 
 #include "mcp/server/mcp_server.h"
 
-#include "mcp/filter/sse_session_registry.h"
-
 #include <algorithm>
 #include <cassert>
 #include <future>
@@ -17,6 +15,7 @@
 #include "mcp/filter/http_sse_filter_chain_factory.h"
 #include "mcp/filter/json_rpc_filter_factory.h"
 #include "mcp/filter/json_rpc_protocol_filter.h"
+#include "mcp/filter/sse_session_registry.h"
 #include "mcp/logging/log_macros.h"
 #include "mcp/transport/http_sse_transport_socket.h"
 // NOTE: We'll implement connection handler directly in server for now
@@ -546,8 +545,7 @@ void McpServer::notifyResourceUpdate(const std::string& uri) {
 
   Metadata params;
   params["uri"] = uri;
-  jsonrpc::Notification notification("notifications/resources/updated",
-                                     params);
+  jsonrpc::Notification notification("notifications/resources/updated", params);
 
   for (const auto& session_id : resource_manager_->getSubscribers(uri)) {
     auto session = session_manager_->getSession(session_id);

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -524,6 +524,40 @@ VoidResult McpServer::sendNotificationToSession(
       Error(jsonrpc::INTERNAL_ERROR, "No active connection for session"));
 }
 
+// Push notifications/resources/updated to every subscriber of the URI
+void McpServer::notifyResourceUpdate(const std::string& uri) {
+  if (!main_dispatcher_) {
+    return;
+  }
+  // Delivery writes to connections, which is dispatcher-thread work; hop
+  // if the application called this from one of its own threads.
+  if (!main_dispatcher_->isThreadSafe()) {
+    main_dispatcher_->post([this, uri]() { notifyResourceUpdate(uri); });
+    return;
+  }
+
+  Metadata params;
+  params["uri"] = uri;
+  jsonrpc::Notification notification("notifications/resources/updated",
+                                     params);
+
+  for (const auto& session_id : resource_manager_->getSubscribers(uri)) {
+    auto session = session_manager_->getSession(session_id);
+    if (!session) {
+      // Subscriber's session expired between bookkeeping and fan-out;
+      // nothing to deliver to.
+      continue;
+    }
+    auto result = sendNotificationToSession(session, notification);
+    if (holds_alternative<std::nullptr_t>(result)) {
+      server_stats_.resource_updates_sent++;
+    } else {
+      GOPHER_LOG_DEBUG("Resource update for {} not delivered to session {}: {}",
+                       uri, session_id, get<Error>(result).message);
+    }
+  }
+}
+
 // Send notification to specific session
 VoidResult McpServer::sendNotification(
     const std::string& session_id, const jsonrpc::Notification& notification) {

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -446,6 +446,14 @@ void McpServer::shutdown() {
       }
       connection_managers_.clear();
 
+      // Release the HTTP+SSE factory here, on the dispatcher thread, after
+      // every connection is gone. The factory owns the SSE session registry
+      // and keeps every created filter alive; if it instead died in
+      // ~McpServer (caller thread), those filter destructors would call
+      // registry.removeSession off the dispatcher thread and trip its
+      // thread assert.
+      http_sse_factory_.reset();
+
       // Exit the blocking dispatch loop.
       main_dispatcher_->exit();
     });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1657,6 +1657,17 @@ target_link_libraries(test_mcp_client_initialize_routing
 )
 add_test(NAME McpClientInitializeRoutingTest COMMAND test_mcp_client_initialize_routing)
 
+add_executable(test_server_notification_delivery integration/test_server_notification_delivery.cc)
+target_link_libraries(test_server_notification_delivery
+    gopher-mcp
+    gopher-mcp-event
+    gtest
+    gtest_main
+    gmock
+    Threads::Threads
+)
+add_test(NAME ServerNotificationDeliveryTest COMMAND test_server_notification_delivery)
+
 add_executable(test_mcp_server_connection_lifecycle integration/test_mcp_server_connection_lifecycle.cc)
 target_link_libraries(test_mcp_server_connection_lifecycle
     gopher-mcp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(test_short_json_api json/test_short_json_api.cc)
 # Server tests
 add_executable(test_mcp_server_responses server/test_mcp_server_responses.cc)
 add_executable(test_resource_read server/test_resource_read.cc)
+add_executable(test_session_manager_capacity server/test_session_manager_capacity.cc)
 # CORS tests
 add_executable(test_cors_headers filter/test_cors_headers.cc)
 add_executable(test_options_notification filter/test_options_notification.cc)
@@ -255,6 +256,14 @@ target_link_libraries(test_mcp_server_responses
 )
 
 target_link_libraries(test_resource_read
+    gopher-mcp
+    gtest
+    gtest_main
+    Threads::Threads
+    fmt::fmt
+)
+
+target_link_libraries(test_session_manager_capacity
     gopher-mcp
     gtest
     gtest_main
@@ -1319,6 +1328,7 @@ add_test(NAME McpSerializationExtensiveTest COMMAND test_mcp_serialization_exten
 add_test(NAME TemplateSerializationTest COMMAND test_template_serialization)
 add_test(NAME McpServerResponsesTest COMMAND test_mcp_server_responses)
 add_test(NAME ResourceReadTest COMMAND test_resource_read)
+add_test(NAME SessionManagerCapacityTest COMMAND test_session_manager_capacity)
 add_test(NAME CorsHeadersTest COMMAND test_cors_headers)
 add_test(NAME OptionsNotificationTest COMMAND test_options_notification)
 add_test(NAME EventLoopTest COMMAND test_event_loop)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,6 +104,7 @@ add_executable(test_tcp_echo_server_basic test_tcp_echo_server_basic.cc)
 # MCP tests
 add_executable(test_mcp_connection_manager network/test_mcp_connection_manager.cc)
 add_executable(test_connection_manager connection/test_connection_manager.cc)
+add_executable(test_endpoint_resolution connection/test_endpoint_resolution.cc)
 add_executable(test_client_disconnect_fixes client/test_client_disconnect_fixes.cc)
 add_executable(test_client_reconnection_and_logging client/test_client_reconnection_and_logging.cc)
 add_executable(test_client_idle_timeout client/test_client_idle_timeout.cc)
@@ -777,6 +778,14 @@ target_link_libraries(test_connection_manager
     Threads::Threads
 )
 
+target_link_libraries(test_endpoint_resolution
+    gopher-mcp
+    gopher-mcp-event
+    gtest
+    gtest_main
+    Threads::Threads
+)
+
 target_link_libraries(test_client_disconnect_fixes
     gopher-mcp
     gopher-mcp-event
@@ -1407,6 +1416,7 @@ add_test(NAME FullStackTransportTest COMMAND test_full_stack_transport)
 # MCP tests
 add_test(NAME McpConnectionManagerTest COMMAND test_mcp_connection_manager)
 add_test(NAME ConnectionManagerTest COMMAND test_connection_manager)
+add_test(NAME EndpointResolutionTest COMMAND test_endpoint_resolution)
 add_test(NAME BuildersTest COMMAND test_builders)
 add_test(NAME McpClientThreadingTest COMMAND test_mcp_client_threading)
 add_test(NAME McpClientMemoryTest COMMAND test_mcp_client_memory)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(test_short_json_api json/test_short_json_api.cc)
 add_executable(test_mcp_server_responses server/test_mcp_server_responses.cc)
 add_executable(test_resource_read server/test_resource_read.cc)
 add_executable(test_session_manager_capacity server/test_session_manager_capacity.cc)
+add_executable(test_session_transport_binding server/test_session_transport_binding.cc)
 # CORS tests
 add_executable(test_cors_headers filter/test_cors_headers.cc)
 add_executable(test_options_notification filter/test_options_notification.cc)
@@ -264,6 +265,14 @@ target_link_libraries(test_resource_read
 )
 
 target_link_libraries(test_session_manager_capacity
+    gopher-mcp
+    gtest
+    gtest_main
+    Threads::Threads
+    fmt::fmt
+)
+
+target_link_libraries(test_session_transport_binding
     gopher-mcp
     gtest
     gtest_main
@@ -1329,6 +1338,7 @@ add_test(NAME TemplateSerializationTest COMMAND test_template_serialization)
 add_test(NAME McpServerResponsesTest COMMAND test_mcp_server_responses)
 add_test(NAME ResourceReadTest COMMAND test_resource_read)
 add_test(NAME SessionManagerCapacityTest COMMAND test_session_manager_capacity)
+add_test(NAME SessionTransportBindingTest COMMAND test_session_transport_binding)
 add_test(NAME CorsHeadersTest COMMAND test_cors_headers)
 add_test(NAME OptionsNotificationTest COMMAND test_options_notification)
 add_test(NAME EventLoopTest COMMAND test_event_loop)

--- a/tests/connection/test_endpoint_resolution.cc
+++ b/tests/connection/test_endpoint_resolution.cc
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for SSE callback endpoint resolution.
+ *
+ * The server's "endpoint" SSE event announces where the client must POST
+ * its JSON-RPC requests. Unless an external URL is configured the server
+ * emits a relative form ("callback/{id}"), but the client's POST path
+ * requires an absolute URL — before resolution existed, every relative
+ * endpoint was rejected as invalid, initialize never reached the server,
+ * and no HTTP+SSE session could be established against this SDK's own
+ * server.
+ *
+ * Rules under test: relative endpoints resolve against the configured
+ * server address (same scheme and host:port as the SSE stream itself);
+ * absolute endpoints pass through untouched; no base means no resolution.
+ */
+
+#include <gtest/gtest.h>
+
+#include "mcp/mcp_connection_manager.h"
+
+using mcp::McpConnectionManager;
+
+namespace {
+
+TEST(EndpointResolutionTest, RelativeEndpointResolvesAgainstServerAddress) {
+  EXPECT_EQ(McpConnectionManager::resolveEndpointUrl(
+                "callback/client_1", "127.0.0.1:8080", /*use_ssl=*/false),
+            "http://127.0.0.1:8080/callback/client_1");
+}
+
+TEST(EndpointResolutionTest, AbsolutePathEndpointResolves) {
+  EXPECT_EQ(McpConnectionManager::resolveEndpointUrl(
+                "/callback/client_1", "127.0.0.1:8080", /*use_ssl=*/false),
+            "http://127.0.0.1:8080/callback/client_1");
+}
+
+TEST(EndpointResolutionTest, SslBaseYieldsHttps) {
+  EXPECT_EQ(McpConnectionManager::resolveEndpointUrl(
+                "callback/client_1", "example.com:443", /*use_ssl=*/true),
+            "https://example.com:443/callback/client_1");
+}
+
+// Reverse-proxy deployments configure external_url and the server then
+// announces an absolute callback URL — it must pass through unchanged,
+// even if it points at a different host than the SSE stream.
+TEST(EndpointResolutionTest, AbsoluteEndpointPassesThrough) {
+  const std::string absolute = "https://proxy.example.com/mcp/callback/c1";
+  EXPECT_EQ(McpConnectionManager::resolveEndpointUrl(absolute, "127.0.0.1:8080",
+                                                     /*use_ssl=*/false),
+            absolute);
+}
+
+// Without a configured server address there is nothing to resolve
+// against; the endpoint is passed through and the POST path reports the
+// invalid URL, which is more diagnosable than fabricating a base.
+TEST(EndpointResolutionTest, NoBasePassesThrough) {
+  EXPECT_EQ(McpConnectionManager::resolveEndpointUrl("callback/client_1", "",
+                                                     /*use_ssl=*/false),
+            "callback/client_1");
+}
+
+TEST(EndpointResolutionTest, EmptyEndpointYieldsBaseRoot) {
+  EXPECT_EQ(McpConnectionManager::resolveEndpointUrl("", "127.0.0.1:8080",
+                                                     /*use_ssl=*/false),
+            "http://127.0.0.1:8080/");
+}
+
+}  // namespace

--- a/tests/filter/test_sse_session_registry.cc
+++ b/tests/filter/test_sse_session_registry.cc
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -171,6 +172,60 @@ TEST_F(SseSessionRegistryTest, MultipleSessionsAreIndependent) {
     EXPECT_FALSE(registry.hasSession(a));
     EXPECT_TRUE(registry.hasSession(b));
     EXPECT_EQ(registry.sessionCount(), 1u);
+  });
+}
+
+// ----------------------------------------------------------------------
+// Session-closed observer.
+// ----------------------------------------------------------------------
+
+// The server layer keys MCP sessions on the registry's ids; the closed
+// callback is how it learns a stream ended so the session (and its
+// subscriptions) can be released. Fired exactly once per real removal.
+TEST_F(SseSessionRegistryTest, ClosedCallbackFiresOncePerRemoval) {
+  executeInDispatcher([this]() {
+    SseSessionRegistry registry(*dispatcher_);
+    std::vector<std::string> closed;
+    registry.setSessionClosedCallback(
+        [&closed](const std::string& id) { closed.push_back(id); });
+
+    const std::string id = registry.registerSession(nullptr);
+    registry.removeSession(id);
+    // Double removal (filter dtor after explicit cleanup) must not
+    // re-announce a session that is already gone.
+    registry.removeSession(id);
+
+    ASSERT_EQ(closed.size(), 1u);
+    EXPECT_EQ(closed[0], id);
+  });
+}
+
+TEST_F(SseSessionRegistryTest, ClosedCallbackSkippedForUnknownId) {
+  executeInDispatcher([this]() {
+    SseSessionRegistry registry(*dispatcher_);
+    bool fired = false;
+    registry.setSessionClosedCallback(
+        [&fired](const std::string&) { fired = true; });
+
+    registry.removeSession("never_registered");
+    EXPECT_FALSE(fired);
+  });
+}
+
+// The observer runs after the entry is erased: re-entrant sends into the
+// closing session must fail cleanly rather than write to a dying stream.
+TEST_F(SseSessionRegistryTest, ClosedCallbackSeesSessionAlreadyGone) {
+  executeInDispatcher([this]() {
+    SseSessionRegistry registry(*dispatcher_);
+    bool routed = true;
+    registry.setSessionClosedCallback(
+        [&registry, &routed](const std::string& id) {
+          routed = registry.sendResponse(id, "{}");
+        });
+
+    const std::string id = registry.registerSession(nullptr);
+    registry.removeSession(id);
+    EXPECT_FALSE(routed);
   });
 }
 

--- a/tests/filter/test_sse_session_registry.cc
+++ b/tests/filter/test_sse_session_registry.cc
@@ -229,6 +229,40 @@ TEST_F(SseSessionRegistryTest, ClosedCallbackSeesSessionAlreadyGone) {
   });
 }
 
+// removeConnection is the close-path removal: the server calls it with
+// the dying connection, and only sessions bound to THAT connection go —
+// with the closed callback fired for each, exactly like removeSession.
+TEST_F(SseSessionRegistryTest, RemoveConnectionDropsOnlyItsSessions) {
+  executeInDispatcher([this]() {
+    SseSessionRegistry registry(*dispatcher_);
+    std::vector<std::string> closed;
+    registry.setSessionClosedCallback(
+        [&closed](const std::string& id) { closed.push_back(id); });
+
+    // Fake pointers used purely as map values; never dereferenced.
+    auto* conn_a = reinterpret_cast<network::Connection*>(0x1);
+    auto* conn_b = reinterpret_cast<network::Connection*>(0x2);
+    const std::string a = registry.registerSession(conn_a);
+    const std::string b = registry.registerSession(conn_b);
+
+    registry.removeConnection(conn_a);
+
+    EXPECT_FALSE(registry.hasSession(a));
+    EXPECT_TRUE(registry.hasSession(b));
+    ASSERT_EQ(closed.size(), 1u);
+    EXPECT_EQ(closed[0], a);
+
+    // Idempotent: the connection is already gone.
+    registry.removeConnection(conn_a);
+    EXPECT_EQ(closed.size(), 1u);
+
+    // Null and unknown connections are safe no-ops.
+    registry.removeConnection(nullptr);
+    registry.removeConnection(reinterpret_cast<network::Connection*>(0x3));
+    EXPECT_EQ(registry.sessionCount(), 1u);
+  });
+}
+
 // ----------------------------------------------------------------------
 // Live-write test (real ConnectionImpl over a TCP socketpair).
 // ----------------------------------------------------------------------

--- a/tests/integration/test_http_sse_filter_server_mode.cc
+++ b/tests/integration/test_http_sse_filter_server_mode.cc
@@ -42,6 +42,10 @@ class ServerModeCallbacks : public McpProtocolCallbacks {
  public:
   void onRequest(const jsonrpc::Request& req) override {
     requests_.push_back(req);
+    // Capture which transport session id was in effect when this request
+    // was dispatched — the filter's contract is to announce it (possibly
+    // empty) immediately beforehand, per message.
+    binding_at_request_.push_back(current_binding_);
   }
   void onNotification(const jsonrpc::Notification&) override {}
   void onResponse(const jsonrpc::Response&) override {}
@@ -49,8 +53,13 @@ class ServerModeCallbacks : public McpProtocolCallbacks {
   void onError(const Error&) override { error_count_++; }
   void onMessageEndpoint(const std::string&) override {}
   bool sendHttpPost(const std::string&) override { return true; }
+  void onTransportSessionBound(const std::string& id) override {
+    current_binding_ = id;
+  }
 
   std::vector<jsonrpc::Request> requests_;
+  std::vector<std::string> binding_at_request_;
+  std::string current_binding_{"<never-announced>"};
   int error_count_{0};
 };
 
@@ -236,6 +245,91 @@ TEST_F(ServerModeFilterTest, PostMcp_PlainHttpMode) {
   if (!callbacks.requests_.empty()) {
     EXPECT_EQ(callbacks.requests_[0].method, "initialize");
   }
+
+  closeOnDispatcher(std::move(conn), std::move(factory));
+}
+
+// ── Transport session announcement ────────────────────────────────
+
+// A request arriving on POST /callback/{id} must be dispatched with the
+// SSE session id from the path already announced — this is what lets the
+// server key its MCP session on the stream instead of the one-shot POST
+// connection.
+TEST_F(ServerModeFilterTest, PostCallback_AnnouncesTransportSessionId) {
+  ServerModeCallbacks callbacks;
+  std::unique_ptr<network::ServerConnection> conn;
+  network::IoHandlePtr peer;
+  std::shared_ptr<HttpSseFilterChainFactory> factory;
+
+  executeInDispatcher([&]() {
+    auto h = makeServerHarness(callbacks);
+    conn = std::move(h.conn);
+    peer = std::move(h.peer);
+    factory = std::move(h.factory);
+
+    std::string body =
+        R"({"jsonrpc":"2.0","method":"resources/subscribe","id":1,"params":{"uri":"test://r"}})";
+    std::string request =
+        "POST /callback/client_7 HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Content-Type: application/json\r\n"
+        "Content-Length: " +
+        std::to_string(body.size()) +
+        "\r\n"
+        "\r\n" +
+        body;
+    writeClientBytes(*peer, request);
+  });
+
+  std::this_thread::sleep_for(200ms);
+
+  ASSERT_EQ(callbacks.requests_.size(), 1u)
+      << "Callback POST body should dispatch as a JSON-RPC request";
+  EXPECT_EQ(callbacks.requests_[0].method, "resources/subscribe");
+  EXPECT_EQ(callbacks.binding_at_request_[0], "client_7")
+      << "Transport session id from the callback path must be announced "
+         "before the request is dispatched";
+
+  closeOnDispatcher(std::move(conn), std::move(factory));
+}
+
+// A plain HTTP request (no callback path) must announce an EMPTY id —
+// requests from different connections interleave on the dispatcher
+// thread, so a stale binding from a previous callback POST must never
+// leak onto the next connection's message.
+TEST_F(ServerModeFilterTest, PlainPost_AnnouncesEmptyBinding) {
+  ServerModeCallbacks callbacks;
+  std::unique_ptr<network::ServerConnection> conn;
+  network::IoHandlePtr peer;
+  std::shared_ptr<HttpSseFilterChainFactory> factory;
+
+  // Pretend a callback POST on another connection just dispatched.
+  callbacks.current_binding_ = "client_from_previous_connection";
+
+  executeInDispatcher([&]() {
+    auto h = makeServerHarness(callbacks);
+    conn = std::move(h.conn);
+    peer = std::move(h.peer);
+    factory = std::move(h.factory);
+
+    std::string body = R"({"jsonrpc":"2.0","method":"ping","id":2})";
+    std::string request =
+        "POST /mcp HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Content-Type: application/json\r\n"
+        "Content-Length: " +
+        std::to_string(body.size()) +
+        "\r\n"
+        "\r\n" +
+        body;
+    writeClientBytes(*peer, request);
+  });
+
+  std::this_thread::sleep_for(200ms);
+
+  ASSERT_EQ(callbacks.requests_.size(), 1u);
+  EXPECT_EQ(callbacks.binding_at_request_[0], "")
+      << "Plain HTTP dispatch must clear any previous connection's binding";
 
   closeOnDispatcher(std::move(conn), std::move(factory));
 }

--- a/tests/integration/test_server_notification_delivery.cc
+++ b/tests/integration/test_server_notification_delivery.cc
@@ -30,6 +30,7 @@
  *   application thread (the deadlock-free hop).
  */
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <future>
@@ -115,12 +116,14 @@ class ServerNotificationDeliveryTest : public ::testing::Test {
   }
 
   void TearDown() override {
-    // Client first so the server observes RemoteClose on a live
+    // Clients first so the server observes RemoteClose on a live
     // dispatcher; then drain the server before joining its thread.
-    if (client_) {
-      client_->shutdown();
-      client_.reset();
+    for (auto& client : clients_) {
+      if (client) {
+        client->shutdown();
+      }
     }
+    clients_.clear();
     if (server_) {
       server_->shutdown();
     }
@@ -156,10 +159,13 @@ class ServerNotificationDeliveryTest : public ::testing::Test {
   }
 
   // Bring up a connected + initialized client over the HTTP+SSE
-  // transport (the /sse path selects it in negotiateTransport).
-  void connectAndInitializeClient() {
+  // transport (the /sse path selects it in negotiateTransport). Each
+  // call creates an independent client with its own SSE stream, so tests
+  // can hold several concurrent sessions against the one server. The
+  // fixture owns the clients (teardown-safe on mid-test failure).
+  client::McpClient* makeConnectedClient(const std::string& name) {
     client::McpClientConfig client_config;
-    client_config.client_name = "notification-delivery-test-client";
+    client_config.client_name = name;
     client_config.client_version = "0.0.1";
     client_config.num_workers = 1;
     // Tight timeouts: a broken leg of the chain should fail the test,
@@ -168,25 +174,50 @@ class ServerNotificationDeliveryTest : public ::testing::Test {
     client_config.protocol_initialization_timeout = 5000ms;
     client_config.protocol_connection_timeout = 5000ms;
 
-    client_ = client::createMcpClient(client_config);
-    ASSERT_NE(client_, nullptr);
+    auto client = client::createMcpClient(client_config);
+    if (!client) {
+      ADD_FAILURE() << "createMcpClient returned null";
+      return nullptr;
+    }
 
     const std::string uri =
         "http://127.0.0.1:" + std::to_string(port_) + "/sse";
-    auto connect_result = client_->connect(uri);
-    ASSERT_TRUE(holds_alternative<std::nullptr_t>(connect_result))
-        << "McpClient::connect failed against real server";
+    auto connect_result = client->connect(uri);
+    if (!holds_alternative<std::nullptr_t>(connect_result)) {
+      ADD_FAILURE() << "McpClient::connect failed against real server";
+      return nullptr;
+    }
 
-    auto init_future = client_->initializeProtocol();
-    ASSERT_EQ(init_future.wait_for(5s), std::future_status::ready)
-        << "initialize never round-tripped over HTTP+SSE";
-    ASSERT_NO_THROW(init_future.get());
+    auto init_future = client->initializeProtocol();
+    if (init_future.wait_for(5s) != std::future_status::ready) {
+      ADD_FAILURE() << "initialize never round-tripped over HTTP+SSE";
+      return nullptr;
+    }
+    try {
+      init_future.get();
+    } catch (const std::exception& e) {
+      ADD_FAILURE() << "initialize failed: " << e.what();
+      return nullptr;
+    }
+
+    clients_.push_back(std::move(client));
+    return clients_.back().get();
+  }
+
+  // Subscribe a client to a resource and require the ack round trip.
+  static bool subscribeAndWait(client::McpClient& client,
+                               const std::string& uri) {
+    auto future = client.subscribeResource(uri);
+    if (future.wait_for(5s) != std::future_status::ready) {
+      return false;
+    }
+    return holds_alternative<std::nullptr_t>(future.get());
   }
 
   uint16_t port_{0};
   std::unique_ptr<server::McpServer> server_;
   std::thread server_thread_;
-  std::unique_ptr<client::McpClient> client_;
+  std::vector<std::unique_ptr<client::McpClient>> clients_;
 };
 
 // The issue #240 scenario: subscribe to a resource, server announces an
@@ -194,13 +225,13 @@ class ServerNotificationDeliveryTest : public ::testing::Test {
 TEST_F(ServerNotificationDeliveryTest, ResourceUpdateReachesSubscriber) {
   const std::string kUri = "test://resource/watched";
 
-  // Registered before connect so no delivery window is open before the
-  // handler exists. Promise is set at most once — the server sends one
-  // update; a second delivery would throw and fail the test.
+  // Promise is set at most once — the server sends one update; a second
+  // delivery would throw and fail the test.
   std::promise<std::string> delivered;
   auto delivered_future = delivered.get_future();
-  connectAndInitializeClient();
-  client_->registerNotificationHandler(
+  auto* client = makeConnectedClient("notification-delivery-test-client");
+  ASSERT_NE(client, nullptr);
+  client->registerNotificationHandler(
       "notifications/resources/updated",
       [&delivered](const jsonrpc::Notification& notification) {
         std::string uri;
@@ -216,12 +247,8 @@ TEST_F(ServerNotificationDeliveryTest, ResourceUpdateReachesSubscriber) {
 
   // Subscribe rides its own one-shot POST connection; the ack coming
   // back proves the request reached the server's session.
-  auto subscribe_future = client_->subscribeResource(kUri);
-  ASSERT_EQ(subscribe_future.wait_for(5s), std::future_status::ready)
+  ASSERT_TRUE(subscribeAndWait(*client, kUri))
       << "resources/subscribe never acknowledged";
-  auto subscribe_result = subscribe_future.get();
-  ASSERT_TRUE(holds_alternative<std::nullptr_t>(subscribe_result))
-      << "resources/subscribe failed";
 
   // Application-side trigger. Called from the test thread (not the
   // server dispatcher) — delivery must hop threads internally.
@@ -237,8 +264,9 @@ TEST_F(ServerNotificationDeliveryTest, ResourceUpdateReachesSubscriber) {
 TEST_F(ServerNotificationDeliveryTest, BroadcastReachesHttpSseClient) {
   std::promise<std::string> delivered;
   auto delivered_future = delivered.get_future();
-  connectAndInitializeClient();
-  client_->registerNotificationHandler(
+  auto* client = makeConnectedClient("notification-delivery-test-client");
+  ASSERT_NE(client, nullptr);
+  client->registerNotificationHandler(
       "test/broadcast", [&delivered](const jsonrpc::Notification& n) {
         std::string payload;
         if (n.params.has_value()) {
@@ -261,6 +289,152 @@ TEST_F(ServerNotificationDeliveryTest, BroadcastReachesHttpSseClient) {
   ASSERT_EQ(delivered_future.wait_for(5s), std::future_status::ready)
       << "broadcast notification never reached the client handler";
   EXPECT_EQ(delivered_future.get(), "hello-subscribers");
+}
+
+// sendNotification called from INSIDE a request handler runs on the
+// dispatcher thread. The pre-fix implementation posted to the dispatcher
+// and blocked on the result — a guaranteed self-deadlock of the event
+// loop from exactly this position. The response future resolving at all
+// is the regression assert; the pushed notification arriving proves the
+// per-session route works end to end.
+TEST_F(ServerNotificationDeliveryTest, SendNotificationFromRequestHandler) {
+  // Unknown session ids must fail cleanly, not silently "succeed".
+  jsonrpc::Notification probe("test/pushed");
+  auto missing = server_->sendNotification("no-such-session", probe);
+  ASSERT_TRUE(holds_alternative<Error>(missing))
+      << "sendNotification to an unknown session must return an error";
+
+  server_->registerRequestHandler(
+      "test/trigger",
+      [this](const jsonrpc::Request& request, server::SessionContext& session)
+          -> jsonrpc::Response {
+        // Dispatcher thread. Push to the requesting session before
+        // answering the request — the classic "tool emits a progress
+        // notification" shape.
+        Metadata params;
+        params["origin"] = std::string("handler");
+        jsonrpc::Notification pushed("test/pushed", params);
+        auto result = server_->sendNotification(session.getId(), pushed);
+        bool sent = holds_alternative<std::nullptr_t>(result);
+        return jsonrpc::Response::success(
+            request.id,
+            jsonrpc::ResponseResult(
+                make<Metadata>().add("notified", sent).build()));
+      });
+
+  std::promise<std::string> delivered;
+  auto delivered_future = delivered.get_future();
+  auto* client = makeConnectedClient("handler-push-test-client");
+  ASSERT_NE(client, nullptr);
+  client->registerNotificationHandler(
+      "test/pushed", [&delivered](const jsonrpc::Notification& n) {
+        std::string origin;
+        if (n.params.has_value()) {
+          auto it = n.params->find("origin");
+          if (it != n.params->end() &&
+              holds_alternative<std::string>(it->second)) {
+            origin = get<std::string>(it->second);
+          }
+        }
+        delivered.set_value(origin);
+      });
+
+  auto response_future = client->sendRequest("test/trigger");
+  // Pre-fix this wait times out: the dispatcher is deadlocked inside the
+  // handler and can never write the response.
+  ASSERT_EQ(response_future.wait_for(5s), std::future_status::ready)
+      << "request never completed — dispatcher likely deadlocked inside "
+         "the handler's sendNotification";
+  ASSERT_NO_THROW(response_future.get());
+
+  ASSERT_EQ(delivered_future.wait_for(5s), std::future_status::ready)
+      << "handler-pushed notification never reached the client";
+  EXPECT_EQ(delivered_future.get(), "handler");
+}
+
+// Delivery must be per-session, not broadcast: only the subscribed
+// client receives the update, and unsubscribing stops further delivery.
+TEST_F(ServerNotificationDeliveryTest, UpdateOnlyReachesSubscribedClient) {
+  const std::string kUri = "test://resource/isolated";
+
+  std::atomic<int> subscriber_count{0};
+  std::atomic<int> bystander_count{0};
+  std::promise<void> first_delivery;
+
+  auto* subscriber = makeConnectedClient("subscriber-client");
+  ASSERT_NE(subscriber, nullptr);
+  auto* bystander = makeConnectedClient("bystander-client");
+  ASSERT_NE(bystander, nullptr);
+
+  subscriber->registerNotificationHandler(
+      "notifications/resources/updated",
+      [&subscriber_count, &first_delivery](const jsonrpc::Notification&) {
+        if (++subscriber_count == 1) {
+          first_delivery.set_value();
+        }
+      });
+  bystander->registerNotificationHandler(
+      "notifications/resources/updated",
+      [&bystander_count](const jsonrpc::Notification&) { bystander_count++; });
+
+  ASSERT_TRUE(subscribeAndWait(*subscriber, kUri));
+
+  server_->notifyResourceUpdate(kUri);
+  ASSERT_EQ(first_delivery.get_future().wait_for(5s),
+            std::future_status::ready)
+      << "subscriber never received the update";
+
+  // Negative assert needs a grace window: give a misrouted copy time to
+  // arrive before declaring it never will.
+  std::this_thread::sleep_for(300ms);
+  EXPECT_EQ(bystander_count.load(), 0)
+      << "unsubscribed client received a per-session resource update";
+
+  // Unsubscribe must stop delivery for later updates.
+  auto unsubscribe_future = subscriber->unsubscribeResource(kUri);
+  ASSERT_EQ(unsubscribe_future.wait_for(5s), std::future_status::ready);
+  ASSERT_TRUE(holds_alternative<std::nullptr_t>(unsubscribe_future.get()));
+
+  server_->notifyResourceUpdate(kUri);
+  std::this_thread::sleep_for(300ms);
+  EXPECT_EQ(subscriber_count.load(), 1)
+      << "update delivered after unsubscribe";
+}
+
+// A subscriber disconnecting (SSE stream close) must release its session
+// server-side: later updates for the same URI still reach the remaining
+// subscriber and nothing crashes on the dead session.
+TEST_F(ServerNotificationDeliveryTest, DisconnectedSubscriberIsReleased) {
+  const std::string kUri = "test://resource/shared";
+
+  auto* leaver = makeConnectedClient("leaving-client");
+  ASSERT_NE(leaver, nullptr);
+  auto* stayer = makeConnectedClient("staying-client");
+  ASSERT_NE(stayer, nullptr);
+
+  std::promise<void> stayer_delivery;
+  stayer->registerNotificationHandler(
+      "notifications/resources/updated",
+      [&stayer_delivery](const jsonrpc::Notification&) {
+        stayer_delivery.set_value();
+      });
+
+  ASSERT_TRUE(subscribeAndWait(*leaver, kUri));
+  ASSERT_TRUE(subscribeAndWait(*stayer, kUri));
+
+  // Tear the first client down; the server sees its SSE stream close and
+  // the registry's session-closed callback releases the session and its
+  // subscriptions on the dispatcher thread.
+  leaver->shutdown();
+  // Give the close event time to propagate through the server dispatcher
+  // before firing the update at the (formerly) shared URI.
+  std::this_thread::sleep_for(300ms);
+
+  server_->notifyResourceUpdate(kUri);
+
+  ASSERT_EQ(stayer_delivery.get_future().wait_for(5s),
+            std::future_status::ready)
+      << "remaining subscriber stopped receiving after peer disconnect";
 }
 
 }  // namespace

--- a/tests/integration/test_server_notification_delivery.cc
+++ b/tests/integration/test_server_notification_delivery.cc
@@ -1,0 +1,267 @@
+/**
+ * Integration test: server-initiated notification delivery over HTTP+SSE.
+ *
+ * End-to-end acceptance for issue #240 — "client can't obtain
+ * notifications from server even though it has registered a callback".
+ * Everything runs over real sockets on loopback; nothing is mocked.
+ *
+ * The full chain under test:
+ *
+ *   1. McpClient connects with an /sse URL: GET opens the SSE stream, the
+ *      server answers with an "endpoint" event carrying a *relative*
+ *      callback URL, and the client resolves it against the server
+ *      address (endpoint-resolution fix) so its POSTs have somewhere to
+ *      go.
+ *   2. initialize and resources/subscribe each ride a one-shot POST
+ *      connection; the server keys the session on the SSE stream id
+ *      announced by the transport filter (transport-session fix), so the
+ *      subscription made on POST #2 lands in the same session initialize
+ *      created — not in a session that died with its POST connection.
+ *   3. McpServer::notifyResourceUpdate builds
+ *      notifications/resources/updated and fans it out to subscribed
+ *      sessions (delivery fix), routing through the SSE session registry
+ *      onto the client's SSE stream (routing fix).
+ *   4. The client's SSE stream parses the event into a JSON-RPC
+ *      notification and dispatches it to the handler registered via
+ *      registerNotificationHandler.
+ *
+ *   A second test covers broadcastNotification reaching an HTTP+SSE
+ *   client on its own stream, including when called from a non-dispatcher
+ *   application thread (the deadlock-free hop).
+ */
+
+#include <chrono>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "mcp/client/mcp_client.h"
+#include "mcp/network/address.h"
+#include "mcp/network/socket_interface.h"
+#include "mcp/server/mcp_server.h"
+#include "mcp/types.h"
+
+namespace mcp {
+namespace {
+
+using namespace std::chrono_literals;
+
+// Pick a loopback port the kernel believes is free by briefly binding
+// ephemeral-port 0. Same accepted TOCTOU trade-off as the other
+// integration tests in this directory.
+uint16_t pickEphemeralPort() {
+  auto& iface = network::socketInterface();
+
+  auto fd_result =
+      iface.socket(network::SocketType::Stream, network::Address::Type::Ip,
+                   network::Address::IpVersion::v4);
+  if (!fd_result.ok()) {
+    throw std::runtime_error("pickEphemeralPort: socket() failed");
+  }
+
+  auto handle = iface.ioHandleForFd(*fd_result, /*socket_v6only=*/false);
+  handle->setBlocking(false);
+
+  auto bind_addr = network::Address::parseInternetAddress("127.0.0.1", 0);
+  auto bind_result = handle->bind(bind_addr);
+  if (!bind_result.ok()) {
+    throw std::runtime_error("pickEphemeralPort: bind() failed");
+  }
+
+  auto local_addr_result = handle->localAddress();
+  if (!local_addr_result.ok()) {
+    throw std::runtime_error("pickEphemeralPort: localAddress() failed");
+  }
+
+  const auto* ip =
+      dynamic_cast<const network::Address::Ip*>(local_addr_result->get());
+  if (ip == nullptr) {
+    throw std::runtime_error("pickEphemeralPort: not an IP address");
+  }
+  uint16_t port = ip->port();
+  handle->close();
+  return port;
+}
+
+class ServerNotificationDeliveryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    port_ = pickEphemeralPort();
+
+    server::McpServerConfig server_config;
+    server_config.server_name = "notification-delivery-test-server";
+    server_config.server_version = "0.0.1";
+    server_config.supported_transports = {TransportType::HttpSse};
+    server_config.num_workers = 1;
+
+    server_ = server::createMcpServer(server_config);
+    ASSERT_NE(server_, nullptr);
+
+    const std::string listen_address =
+        "http://127.0.0.1:" + std::to_string(port_);
+    auto listen_result = server_->listen(listen_address);
+    ASSERT_TRUE(holds_alternative<std::nullptr_t>(listen_result))
+        << "McpServer::listen failed";
+
+    server_thread_ = std::thread([this]() { server_->run(); });
+
+    ASSERT_TRUE(waitForListenerReady(port_, 5s))
+        << "Server did not begin accepting on port " << port_;
+  }
+
+  void TearDown() override {
+    // Client first so the server observes RemoteClose on a live
+    // dispatcher; then drain the server before joining its thread.
+    if (client_) {
+      client_->shutdown();
+      client_.reset();
+    }
+    if (server_) {
+      server_->shutdown();
+    }
+    if (server_thread_.joinable()) {
+      server_thread_.join();
+    }
+    server_.reset();
+  }
+
+  // Connect-probe until the listener accepts (McpServer::listen gives no
+  // readiness signal).
+  static bool waitForListenerReady(uint16_t port,
+                                   std::chrono::milliseconds budget) {
+    auto& iface = network::socketInterface();
+    auto addr = network::Address::parseInternetAddress("127.0.0.1", port);
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+      auto fd_result =
+          iface.socket(network::SocketType::Stream, network::Address::Type::Ip,
+                       network::Address::IpVersion::v4);
+      if (fd_result.ok()) {
+        auto handle = iface.ioHandleForFd(*fd_result, false);
+        handle->setBlocking(true);
+        auto connect_result = handle->connect(addr);
+        handle->close();
+        if (connect_result.ok()) {
+          return true;
+        }
+      }
+      std::this_thread::sleep_for(25ms);
+    }
+    return false;
+  }
+
+  // Bring up a connected + initialized client over the HTTP+SSE
+  // transport (the /sse path selects it in negotiateTransport).
+  void connectAndInitializeClient() {
+    client::McpClientConfig client_config;
+    client_config.client_name = "notification-delivery-test-client";
+    client_config.client_version = "0.0.1";
+    client_config.num_workers = 1;
+    // Tight timeouts: a broken leg of the chain should fail the test,
+    // not hang it.
+    client_config.request_timeout = 5000ms;
+    client_config.protocol_initialization_timeout = 5000ms;
+    client_config.protocol_connection_timeout = 5000ms;
+
+    client_ = client::createMcpClient(client_config);
+    ASSERT_NE(client_, nullptr);
+
+    const std::string uri =
+        "http://127.0.0.1:" + std::to_string(port_) + "/sse";
+    auto connect_result = client_->connect(uri);
+    ASSERT_TRUE(holds_alternative<std::nullptr_t>(connect_result))
+        << "McpClient::connect failed against real server";
+
+    auto init_future = client_->initializeProtocol();
+    ASSERT_EQ(init_future.wait_for(5s), std::future_status::ready)
+        << "initialize never round-tripped over HTTP+SSE";
+    ASSERT_NO_THROW(init_future.get());
+  }
+
+  uint16_t port_{0};
+  std::unique_ptr<server::McpServer> server_;
+  std::thread server_thread_;
+  std::unique_ptr<client::McpClient> client_;
+};
+
+// The issue #240 scenario: subscribe to a resource, server announces an
+// update, the registered client callback fires with the right URI.
+TEST_F(ServerNotificationDeliveryTest, ResourceUpdateReachesSubscriber) {
+  const std::string kUri = "test://resource/watched";
+
+  // Registered before connect so no delivery window is open before the
+  // handler exists. Promise is set at most once — the server sends one
+  // update; a second delivery would throw and fail the test.
+  std::promise<std::string> delivered;
+  auto delivered_future = delivered.get_future();
+  connectAndInitializeClient();
+  client_->registerNotificationHandler(
+      "notifications/resources/updated",
+      [&delivered](const jsonrpc::Notification& notification) {
+        std::string uri;
+        if (notification.params.has_value()) {
+          auto it = notification.params->find("uri");
+          if (it != notification.params->end() &&
+              holds_alternative<std::string>(it->second)) {
+            uri = get<std::string>(it->second);
+          }
+        }
+        delivered.set_value(uri);
+      });
+
+  // Subscribe rides its own one-shot POST connection; the ack coming
+  // back proves the request reached the server's session.
+  auto subscribe_future = client_->subscribeResource(kUri);
+  ASSERT_EQ(subscribe_future.wait_for(5s), std::future_status::ready)
+      << "resources/subscribe never acknowledged";
+  auto subscribe_result = subscribe_future.get();
+  ASSERT_TRUE(holds_alternative<std::nullptr_t>(subscribe_result))
+      << "resources/subscribe failed";
+
+  // Application-side trigger. Called from the test thread (not the
+  // server dispatcher) — delivery must hop threads internally.
+  server_->notifyResourceUpdate(kUri);
+
+  ASSERT_EQ(delivered_future.wait_for(5s), std::future_status::ready)
+      << "notifications/resources/updated never reached the client handler";
+  EXPECT_EQ(delivered_future.get(), kUri);
+}
+
+// broadcastNotification must reach an HTTP+SSE client through its own SSE
+// stream, without requiring a resource subscription.
+TEST_F(ServerNotificationDeliveryTest, BroadcastReachesHttpSseClient) {
+  std::promise<std::string> delivered;
+  auto delivered_future = delivered.get_future();
+  connectAndInitializeClient();
+  client_->registerNotificationHandler(
+      "test/broadcast", [&delivered](const jsonrpc::Notification& n) {
+        std::string payload;
+        if (n.params.has_value()) {
+          auto it = n.params->find("payload");
+          if (it != n.params->end() &&
+              holds_alternative<std::string>(it->second)) {
+            payload = get<std::string>(it->second);
+          }
+        }
+        delivered.set_value(payload);
+      });
+
+  Metadata params;
+  params["payload"] = std::string("hello-subscribers");
+  jsonrpc::Notification notification("test/broadcast", params);
+
+  // Off-dispatcher caller: exercises the post-to-dispatcher hop.
+  server_->broadcastNotification(notification);
+
+  ASSERT_EQ(delivered_future.wait_for(5s), std::future_status::ready)
+      << "broadcast notification never reached the client handler";
+  EXPECT_EQ(delivered_future.get(), "hello-subscribers");
+}
+
+}  // namespace
+}  // namespace mcp

--- a/tests/integration/test_server_notification_delivery.cc
+++ b/tests/integration/test_server_notification_delivery.cc
@@ -306,8 +306,8 @@ TEST_F(ServerNotificationDeliveryTest, SendNotificationFromRequestHandler) {
 
   server_->registerRequestHandler(
       "test/trigger",
-      [this](const jsonrpc::Request& request, server::SessionContext& session)
-          -> jsonrpc::Response {
+      [this](const jsonrpc::Request& request,
+             server::SessionContext& session) -> jsonrpc::Response {
         // Dispatcher thread. Push to the requesting session before
         // answering the request — the classic "tool emits a progress
         // notification" shape.
@@ -317,9 +317,8 @@ TEST_F(ServerNotificationDeliveryTest, SendNotificationFromRequestHandler) {
         auto result = server_->sendNotification(session.getId(), pushed);
         bool sent = holds_alternative<std::nullptr_t>(result);
         return jsonrpc::Response::success(
-            request.id,
-            jsonrpc::ResponseResult(
-                make<Metadata>().add("notified", sent).build()));
+            request.id, jsonrpc::ResponseResult(
+                            make<Metadata>().add("notified", sent).build()));
       });
 
   std::promise<std::string> delivered;
@@ -380,8 +379,7 @@ TEST_F(ServerNotificationDeliveryTest, UpdateOnlyReachesSubscribedClient) {
   ASSERT_TRUE(subscribeAndWait(*subscriber, kUri));
 
   server_->notifyResourceUpdate(kUri);
-  ASSERT_EQ(first_delivery.get_future().wait_for(5s),
-            std::future_status::ready)
+  ASSERT_EQ(first_delivery.get_future().wait_for(5s), std::future_status::ready)
       << "subscriber never received the update";
 
   // Negative assert needs a grace window: give a misrouted copy time to
@@ -397,8 +395,7 @@ TEST_F(ServerNotificationDeliveryTest, UpdateOnlyReachesSubscribedClient) {
 
   server_->notifyResourceUpdate(kUri);
   std::this_thread::sleep_for(300ms);
-  EXPECT_EQ(subscriber_count.load(), 1)
-      << "update delivered after unsubscribe";
+  EXPECT_EQ(subscriber_count.load(), 1) << "update delivered after unsubscribe";
 }
 
 // A subscriber disconnecting (SSE stream close) must release its session

--- a/tests/server/test_session_manager_capacity.cc
+++ b/tests/server/test_session_manager_capacity.cc
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for SessionManager capacity handling.
+ *
+ * Regression coverage for a self-deadlock: the at-capacity path in
+ * createSession() called the locking cleanupExpiredSessions() while
+ * already holding the non-recursive session mutex, so the first time
+ * max_sessions was reached the server hung instead of rejecting the
+ * session. The tests assert prompt rejection when nothing is expired and
+ * successful reclamation when expired sessions can be swept.
+ */
+
+#include <gtest/gtest.h>
+
+#include "mcp/server/mcp_server.h"
+
+using namespace mcp;
+using namespace mcp::server;
+
+namespace {
+
+class SessionManagerCapacityTest : public ::testing::Test {
+ protected:
+  McpServerConfig config_;
+  McpServerStats stats_;
+};
+
+// With a generous timeout nothing is expired, so hitting max_sessions
+// must return null promptly. Before the fix this test hung forever on
+// the second createSession call.
+TEST_F(SessionManagerCapacityTest, AtCapacityReturnsNullWithoutDeadlock) {
+  config_.max_sessions = 1;
+  SessionManager manager(config_, stats_);
+
+  ASSERT_NE(manager.createSession(nullptr), nullptr);
+  EXPECT_EQ(manager.createSession(nullptr), nullptr);
+}
+
+// With an instant timeout the at-capacity sweep can reclaim the expired
+// session, so the create succeeds — proving the sweep actually runs
+// inside the locked path rather than being skipped.
+TEST_F(SessionManagerCapacityTest, AtCapacityReclaimsExpiredSessions) {
+  config_.max_sessions = 1;
+  config_.session_timeout = std::chrono::milliseconds(0);
+  SessionManager manager(config_, stats_);
+
+  auto first = manager.createSession(nullptr);
+  ASSERT_NE(first, nullptr);
+
+  auto second = manager.createSession(nullptr);
+  ASSERT_NE(second, nullptr);
+  EXPECT_NE(second->getId(), first->getId());
+  EXPECT_EQ(stats_.sessions_expired.load(), 1u);
+}
+
+// The public sweep still works standalone (wrapper over the shared body).
+TEST_F(SessionManagerCapacityTest, PublicCleanupSweepsExpiredSessions) {
+  config_.session_timeout = std::chrono::milliseconds(0);
+  SessionManager manager(config_, stats_);
+
+  auto session = manager.createSession(nullptr);
+  ASSERT_NE(session, nullptr);
+
+  manager.cleanupExpiredSessions();
+  EXPECT_EQ(manager.getSession(session->getId()), nullptr);
+}
+
+}  // namespace

--- a/tests/server/test_session_transport_binding.cc
+++ b/tests/server/test_session_transport_binding.cc
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for transport-session keyed MCP sessions.
+ *
+ * HTTP+SSE clients send every JSON-RPC request on a fresh one-shot POST
+ * connection, so a session keyed on the connection pointer would be a new
+ * session per request and per-session state (resource subscriptions,
+ * client info) would silently evaporate. SessionManager therefore also
+ * keys sessions on the durable transport session id (the SSE stream id
+ * from the POST /callback/{id} path).
+ *
+ * Covers:
+ * - get-or-create by transport id is stable across calls (the fix that
+ *   lets a subscription made on POST #1 still exist on POST #2)
+ * - transport-keyed sessions are independent of connection tracking, so a
+ *   POST connection closing does not tear them down
+ * - removal by transport id (SSE stream close) and via removeSession keep
+ *   both indexes consistent
+ * - the expiry sweep also cleans the transport index
+ * - the at-capacity path applies to transport-keyed creation too
+ */
+
+#include <gtest/gtest.h>
+
+#include "mcp/server/mcp_server.h"
+
+using namespace mcp;
+using namespace mcp::server;
+
+namespace {
+
+class SessionTransportBindingTest : public ::testing::Test {
+ protected:
+  McpServerConfig config_;
+  McpServerStats stats_;
+};
+
+// The core property behind issue #240: two requests arriving on different
+// (short-lived) connections but carrying the same transport session id
+// must resolve to the same session.
+TEST_F(SessionTransportBindingTest, SameTransportIdSameSession) {
+  SessionManager manager(config_, stats_);
+
+  auto first = manager.getOrCreateSessionByTransportId("client_1");
+  auto second = manager.getOrCreateSessionByTransportId("client_1");
+
+  ASSERT_NE(first, nullptr);
+  EXPECT_EQ(first, second);
+  EXPECT_EQ(stats_.sessions_total.load(), 1u);
+}
+
+TEST_F(SessionTransportBindingTest, DifferentTransportIdsDistinctSessions) {
+  SessionManager manager(config_, stats_);
+
+  auto first = manager.getOrCreateSessionByTransportId("client_1");
+  auto second = manager.getOrCreateSessionByTransportId("client_2");
+
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+  EXPECT_NE(first->getId(), second->getId());
+}
+
+// Transport-keyed sessions deliberately carry no connection: the POST
+// connection a request arrived on is already closing, and tracking it
+// would let its close event destroy the session.
+TEST_F(SessionTransportBindingTest, TransportSessionHasNoConnection) {
+  SessionManager manager(config_, stats_);
+
+  auto session = manager.getOrCreateSessionByTransportId("client_1");
+
+  ASSERT_NE(session, nullptr);
+  EXPECT_EQ(session->getConnection(), nullptr);
+  EXPECT_EQ(session->getTransportSessionId(), "client_1");
+}
+
+TEST_F(SessionTransportBindingTest, LookupWithoutCreation) {
+  SessionManager manager(config_, stats_);
+
+  EXPECT_EQ(manager.getSessionByTransportId("client_1"), nullptr);
+  auto created = manager.getOrCreateSessionByTransportId("client_1");
+  EXPECT_EQ(manager.getSessionByTransportId("client_1"), created);
+}
+
+// SSE stream close path: removal returns the session so the caller can
+// release subscription state, and the id becomes free again.
+TEST_F(SessionTransportBindingTest, RemoveByTransportId) {
+  SessionManager manager(config_, stats_);
+
+  auto session = manager.getOrCreateSessionByTransportId("client_1");
+  ASSERT_NE(session, nullptr);
+
+  auto removed = manager.removeSessionByTransportId("client_1");
+  EXPECT_EQ(removed, session);
+  EXPECT_EQ(manager.getSession(session->getId()), nullptr);
+  EXPECT_EQ(manager.getSessionByTransportId("client_1"), nullptr);
+
+  // Idempotent: second removal is a no-op.
+  EXPECT_EQ(manager.removeSessionByTransportId("client_1"), nullptr);
+
+  // A new stream reusing the id gets a fresh session, not the dead one.
+  auto fresh = manager.getOrCreateSessionByTransportId("client_1");
+  ASSERT_NE(fresh, nullptr);
+  EXPECT_NE(fresh->getId(), session->getId());
+}
+
+// removeSession (by MCP session id) must keep the transport index in sync,
+// otherwise the next getOrCreate would resurrect a removed session.
+TEST_F(SessionTransportBindingTest, RemoveSessionClearsTransportIndex) {
+  SessionManager manager(config_, stats_);
+
+  auto session = manager.getOrCreateSessionByTransportId("client_1");
+  ASSERT_NE(session, nullptr);
+
+  manager.removeSession(session->getId());
+  EXPECT_EQ(manager.getSessionByTransportId("client_1"), nullptr);
+}
+
+// The expiry sweep must clean the transport index too, or an expired id
+// would keep resolving to a destroyed session.
+TEST_F(SessionTransportBindingTest, ExpirySweepCleansTransportIndex) {
+  config_.session_timeout = std::chrono::milliseconds(0);
+  SessionManager manager(config_, stats_);
+
+  auto session = manager.getOrCreateSessionByTransportId("client_1");
+  ASSERT_NE(session, nullptr);
+
+  manager.cleanupExpiredSessions();
+
+  EXPECT_EQ(manager.getSessionByTransportId("client_1"), nullptr);
+  EXPECT_EQ(manager.getSession(session->getId()), nullptr);
+  EXPECT_EQ(stats_.sessions_expired.load(), 1u);
+}
+
+// The session limit covers transport-keyed sessions too, and rejection is
+// prompt (shares the non-recursive-mutex-safe sweep with createSession).
+TEST_F(SessionTransportBindingTest, AtCapacityReturnsNull) {
+  config_.max_sessions = 1;
+  SessionManager manager(config_, stats_);
+
+  ASSERT_NE(manager.getOrCreateSessionByTransportId("client_1"), nullptr);
+  EXPECT_EQ(manager.getOrCreateSessionByTransportId("client_2"), nullptr);
+}
+
+}  // namespace

--- a/tests/server/test_session_transport_binding.cc
+++ b/tests/server/test_session_transport_binding.cc
@@ -140,4 +140,65 @@ TEST_F(SessionTransportBindingTest, AtCapacityReturnsNull) {
   EXPECT_EQ(manager.getOrCreateSessionByTransportId("client_2"), nullptr);
 }
 
+// A closing POST connection fires removeSessionByConnection; that must
+// never collaterally destroy a transport-keyed session.
+TEST_F(SessionTransportBindingTest,
+       ConnectionRemovalDoesNotTouchTransportSessions) {
+  SessionManager manager(config_, stats_);
+
+  auto transport_session = manager.getOrCreateSessionByTransportId("client_1");
+  ASSERT_NE(transport_session, nullptr);
+
+  // Simulate the close of some unrelated connection-keyed session. The
+  // fake pointer is only used as a map key, never dereferenced.
+  auto* fake_conn = reinterpret_cast<network::Connection*>(0x1);
+  auto conn_session = manager.createSession(fake_conn);
+  ASSERT_NE(conn_session, nullptr);
+
+  auto removed = manager.removeSessionByConnection(fake_conn);
+  EXPECT_EQ(removed, conn_session);
+
+  EXPECT_EQ(manager.getSessionByTransportId("client_1"), transport_session);
+  EXPECT_EQ(manager.getSession(transport_session->getId()), transport_session);
+}
+
+// ---------------------------------------------------------------------------
+// ResourceManager::releaseSession
+// ---------------------------------------------------------------------------
+
+// When a session ends, its subscriptions must leave the fan-out map, so a
+// later resource update no longer targets the dead session id.
+TEST_F(SessionTransportBindingTest, ReleaseSessionDropsSubscriptions) {
+  ResourceManager resources(stats_);
+  SessionContext session("session_1", nullptr);
+
+  resources.subscribe("res://a", session);
+  resources.subscribe("res://b", session);
+
+  resources.releaseSession(session);
+
+  // Updates after release must not queue anything for the dead session.
+  resources.notifyResourceUpdate("res://a");
+  resources.notifyResourceUpdate("res://b");
+  EXPECT_TRUE(resources.getPendingUpdates("session_1").empty());
+}
+
+// Release must only drop the dying session's subscriptions, not other
+// subscribers of the same URI.
+TEST_F(SessionTransportBindingTest, ReleaseSessionKeepsOtherSubscribers) {
+  ResourceManager resources(stats_);
+  SessionContext dying("session_1", nullptr);
+  SessionContext staying("session_2", nullptr);
+
+  resources.subscribe("res://a", dying);
+  resources.subscribe("res://a", staying);
+
+  resources.releaseSession(dying);
+  resources.notifyResourceUpdate("res://a");
+
+  EXPECT_TRUE(resources.getPendingUpdates("session_1").empty());
+  auto updates = resources.getPendingUpdates("session_2");
+  EXPECT_EQ(updates.count("res://a"), 1u);
+}
+
 }  // namespace

--- a/tests/server/test_session_transport_binding.cc
+++ b/tests/server/test_session_transport_binding.cc
@@ -166,6 +166,21 @@ TEST_F(SessionTransportBindingTest,
 // ResourceManager::releaseSession
 // ---------------------------------------------------------------------------
 
+// getSubscribers is what the server fans notifications out from: it must
+// reflect subscribe/unsubscribe exactly.
+TEST_F(SessionTransportBindingTest, SubscribersTrackSubscribeUnsubscribe) {
+  ResourceManager resources(stats_);
+  SessionContext session("session_1", nullptr);
+
+  EXPECT_TRUE(resources.getSubscribers("res://a").empty());
+
+  resources.subscribe("res://a", session);
+  EXPECT_EQ(resources.getSubscribers("res://a").count("session_1"), 1u);
+
+  resources.unsubscribe("res://a", session);
+  EXPECT_TRUE(resources.getSubscribers("res://a").empty());
+}
+
 // When a session ends, its subscriptions must leave the fan-out map, so a
 // later resource update no longer targets the dead session id.
 TEST_F(SessionTransportBindingTest, ReleaseSessionDropsSubscriptions) {
@@ -177,10 +192,8 @@ TEST_F(SessionTransportBindingTest, ReleaseSessionDropsSubscriptions) {
 
   resources.releaseSession(session);
 
-  // Updates after release must not queue anything for the dead session.
-  resources.notifyResourceUpdate("res://a");
-  resources.notifyResourceUpdate("res://b");
-  EXPECT_TRUE(resources.getPendingUpdates("session_1").empty());
+  EXPECT_TRUE(resources.getSubscribers("res://a").empty());
+  EXPECT_TRUE(resources.getSubscribers("res://b").empty());
 }
 
 // Release must only drop the dying session's subscriptions, not other
@@ -194,11 +207,10 @@ TEST_F(SessionTransportBindingTest, ReleaseSessionKeepsOtherSubscribers) {
   resources.subscribe("res://a", staying);
 
   resources.releaseSession(dying);
-  resources.notifyResourceUpdate("res://a");
 
-  EXPECT_TRUE(resources.getPendingUpdates("session_1").empty());
-  auto updates = resources.getPendingUpdates("session_2");
-  EXPECT_EQ(updates.count("res://a"), 1u);
+  auto subscribers = resources.getSubscribers("res://a");
+  EXPECT_EQ(subscribers.count("session_1"), 0u);
+  EXPECT_EQ(subscribers.count("session_2"), 1u);
 }
 
 }  // namespace


### PR DESCRIPTION
## Original ticket
https://github.com/GopherSecurity/gopher-mcp/issues/240 (follow-up to #234 / PR #237)

## Summary

PR #237 gave `McpClient` a `registerNotificationHandler` API, but registered callbacks still never fired (v0.1.6): the wiring above and below that layer was broken independently on both ends. This PR repairs the full chain so a client subscribed over HTTP+SSE actually receives `notifications/resources/updated`, and `sendNotification` / `broadcastNotification` reach HTTP+SSE clients at all.

## Root causes fixed

**Server side**
- Sessions were keyed on the connection pointer, but HTTP+SSE clients send every request on a one-shot POST connection — each request got a fresh session and subscriptions evaporated between requests. Sessions are now keyed on the durable SSE stream id, announced by the transport filter immediately before each message dispatch (`McpProtocolCallbacks::onTransportSessionBound`).
- `notifyResourceUpdate()` queued URIs into a pending-updates map whose drain had **zero callers** — updates were counted as sent and accumulated forever. It now builds `notifications/resources/updated` and fans it out immediately to every subscribed session.
- `sendNotification(session_id, ...)` looked the session up and then ignored it, sending on the first connected connection manager — a vector only the stdio path populates, so HTTP+SSE always failed with "No active connection for session". It also blocked on a future fulfilled by a task posted to the dispatcher, deadlocking the event loop when called from a tool/request handler. Delivery is now routed per session (SSE stream via the registry / owning connection / stdio manager) and runs inline when already on the dispatcher thread.
- Session lifetime is bounded by the transport session: when the client's SSE stream closes, the session and its resource subscriptions are released (new `SseSessionRegistry` session-closed observer).

**Client side**
- The server's `endpoint` event announces a relative callback URL (`callback/{id}`) unless `external_url` is configured, and the client's POST path rejected any URL without a scheme — so `initialize` never even reached the server. Relative endpoints now resolve against the server address the SSE stream is connected to.

**Also**
- Fixed a latent self-deadlock in `SessionManager` the first time `max_sessions` was reached.
- The C API `mcp_server_send_notification` stub returned `MCP_SUCCESS` while dropping the notification; it now returns `MCP_ERROR_NOT_IMPLEMENTED` until the C server facade is wired up.

## Why HTTP+SSE (not Streamable HTTP)

Streamable HTTP in this codebase is POST request/response only: no standing GET event stream, `Mcp-Session-Id` is never assigned or read, and the client state machine rejects SSE-typed responses — there is no channel for server-initiated messages. HTTP+SSE already had the complete receive pipeline, so the fix lands there; Streamable HTTP GET-stream support is a natural follow-up.

## Commits

Thirteen small, independently reviewable commits: deadlock fix → registry observer → transport-session announcement → session keying → subscription release → server wiring → routed send → resource-update delivery → client endpoint resolution → C API honesty → shutdown-ordering fix → end-to-end test → format.

## Tests

- `tests/integration/test_server_notification_delivery.cc` — end-to-end acceptance over real loopback sockets: connect via `/sse`, initialize, `resources/subscribe`, `notifyResourceUpdate()` from an application thread, assert the registered client handler fires with the right URI; plus `broadcastNotification` from a non-dispatcher thread.
- New unit suites: session transport binding (12), session-manager capacity (3), SSE registry closed-callback (3 new, 10 total), endpoint resolution (6).
- Existing server/client/filter/integration suites all pass.