### PR TITLE
Fix correctness bugs in server notification delivery

### DIFF
--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -583,36 +583,59 @@ class SessionManager {
   SessionManager(const McpServerConfig& config, McpServerStats& stats)
       : config_(config), stats_(stats) {}
 
+  // Observer invoked once for each session removed by the expiry sweep, on
+  // the thread that triggered the sweep (the dispatcher thread: background
+  // cleanup timer, or the at-capacity path of a session create). It fires
+  // AFTER mutex_ is released, so the callback may safely take other locks
+  // (e.g. ResourceManager's) without lock-ordering hazards. This is how the
+  // server releases state it keys on a session — resource subscriptions —
+  // that would otherwise leak when a session times out. The explicit
+  // removeSession/removeSessionByConnection/removeSessionByTransportId
+  // paths do NOT fire it; their callers already hold the removed session
+  // and release such state directly.
+  using SessionRemovedCallback = std::function<void(const SessionPtr&)>;
+  void setSessionRemovedCallback(SessionRemovedCallback callback) {
+    session_removed_callback_ = std::move(callback);
+  }
+
   // Create new session
   SessionPtr createSession(network::Connection* connection) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    SessionPtr session;
+    std::vector<SessionPtr> expired;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
 
-    // Check max sessions limit. Use the Locked variant — mutex_ is already
-    // held here and is not recursive, so calling the public
-    // cleanupExpiredSessions() would self-deadlock.
-    if (sessions_.size() >= config_.max_sessions) {
-      // Try to clean up expired sessions first
-      cleanupExpiredSessionsLocked();
+      // Check max sessions limit. Use the Locked variant — mutex_ is already
+      // held here and is not recursive, so calling the public
+      // cleanupExpiredSessions() would self-deadlock.
       if (sessions_.size() >= config_.max_sessions) {
-        return nullptr;  // Max sessions reached
+        // Try to clean up expired sessions first
+        cleanupExpiredSessionsLocked(expired);
+        if (sessions_.size() >= config_.max_sessions) {
+          fireSessionRemoved(expired);
+          return nullptr;  // Max sessions reached
+        }
       }
+
+      // Generate session ID
+      std::string session_id = generateSessionId();
+
+      // Create session
+      session = std::make_shared<SessionContext>(session_id, connection);
+      sessions_[session_id] = session;
+
+      // Track by connection if available
+      if (connection) {
+        connection_sessions_[connection] = session;
+      }
+
+      stats_.sessions_total++;
+      stats_.sessions_active++;
     }
 
-    // Generate session ID
-    std::string session_id = generateSessionId();
-
-    // Create session
-    auto session = std::make_shared<SessionContext>(session_id, connection);
-    sessions_[session_id] = session;
-
-    // Track by connection if available
-    if (connection) {
-      connection_sessions_[connection] = session;
-    }
-
-    stats_.sessions_total++;
-    stats_.sessions_active++;
-
+    // Fire removal observers for any sessions the capacity sweep evicted,
+    // outside the lock.
+    fireSessionRemoved(expired);
     return session;
   }
 
@@ -639,29 +662,35 @@ class SessionManager {
   // close) plus the usual expiry sweep.
   SessionPtr getOrCreateSessionByTransportId(
       const std::string& transport_session_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    SessionPtr session;
+    std::vector<SessionPtr> expired;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
 
-    auto it = transport_sessions_.find(transport_session_id);
-    if (it != transport_sessions_.end()) {
-      it->second->updateActivity();
-      return it->second;
-    }
-
-    if (sessions_.size() >= config_.max_sessions) {
-      cleanupExpiredSessionsLocked();
-      if (sessions_.size() >= config_.max_sessions) {
-        return nullptr;  // Max sessions reached
+      auto it = transport_sessions_.find(transport_session_id);
+      if (it != transport_sessions_.end()) {
+        it->second->updateActivity();
+        return it->second;
       }
+
+      if (sessions_.size() >= config_.max_sessions) {
+        cleanupExpiredSessionsLocked(expired);
+        if (sessions_.size() >= config_.max_sessions) {
+          fireSessionRemoved(expired);
+          return nullptr;  // Max sessions reached
+        }
+      }
+
+      session = std::make_shared<SessionContext>(generateSessionId(), nullptr);
+      session->setTransportSessionId(transport_session_id);
+      sessions_[session->getId()] = session;
+      transport_sessions_[transport_session_id] = session;
+
+      stats_.sessions_total++;
+      stats_.sessions_active++;
     }
 
-    auto session =
-        std::make_shared<SessionContext>(generateSessionId(), nullptr);
-    session->setTransportSessionId(transport_session_id);
-    sessions_[session->getId()] = session;
-    transport_sessions_[transport_session_id] = session;
-
-    stats_.sessions_total++;
-    stats_.sessions_active++;
+    fireSessionRemoved(expired);
     return session;
   }
 
@@ -736,10 +765,15 @@ class SessionManager {
     return (it != connection_sessions_.end()) ? it->second : nullptr;
   }
 
-  // Clean up expired sessions
+  // Clean up expired sessions. Fires the session-removed observer for each
+  // swept session, outside the lock.
   void cleanupExpiredSessions() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    cleanupExpiredSessionsLocked();
+    std::vector<SessionPtr> expired;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      cleanupExpiredSessionsLocked(expired);
+    }
+    fireSessionRemoved(expired);
   }
 
   // Enumerate active sessions (snapshot). Used by broadcast paths, which
@@ -755,13 +789,34 @@ class SessionManager {
   }
 
  private:
+  // Fire the session-removed observer for each session, if one is set.
+  // Called only with mutex_ released.
+  void fireSessionRemoved(const std::vector<SessionPtr>& removed) {
+    if (!session_removed_callback_) {
+      return;
+    }
+    for (const auto& session : removed) {
+      session_removed_callback_(session);
+    }
+  }
+
   // Expiry sweep body shared by the public entry point and the
   // at-capacity path inside createSession / getOrCreateSessionByTransportId,
-  // which already hold mutex_ (non-recursive).
-  void cleanupExpiredSessionsLocked() {
+  // which already hold mutex_ (non-recursive). Appends every removed session
+  // to `removed` so the caller can fire observers after releasing the lock.
+  void cleanupExpiredSessionsLocked(std::vector<SessionPtr>& removed) {
     std::vector<std::string> expired;
 
     for (const auto& pair : sessions_) {
+      // Transport-keyed sessions (HTTP+SSE) are NOT subject to activity
+      // expiry: their lifetime is bounded by the SSE stream closing
+      // (removeSessionByTransportId), and the client may legitimately hold
+      // an idle-but-open stream far longer than session_timeout. Expiring
+      // one here would silently drop a live client's session — and its
+      // resource subscriptions — while its stream is still connected.
+      if (!pair.second->getTransportSessionId().empty()) {
+        continue;
+      }
       if (pair.second->isExpired(config_.session_timeout)) {
         expired.push_back(pair.first);
       }
@@ -774,9 +829,7 @@ class SessionManager {
         if (it->second->getConnection()) {
           connection_sessions_.erase(it->second->getConnection());
         }
-        if (!it->second->getTransportSessionId().empty()) {
-          transport_sessions_.erase(it->second->getTransportSessionId());
-        }
+        removed.push_back(it->second);
         sessions_.erase(it);
         stats_.sessions_expired++;
         stats_.sessions_active--;
@@ -796,6 +849,7 @@ class SessionManager {
   // on short-lived connections (HTTP+SSE POST callbacks). Kept consistent
   // with sessions_ by every mutation path above.
   std::map<std::string, SessionPtr> transport_sessions_;
+  SessionRemovedCallback session_removed_callback_;
   McpServerConfig config_;
   McpServerStats& stats_;
 };

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -573,28 +573,46 @@ void McpServer::notifyResourceUpdate(const std::string& uri) {
 // Send notification to specific session
 VoidResult McpServer::sendNotification(
     const std::string& session_id, const jsonrpc::Notification& notification) {
-  // Get session
-  auto session = session_manager_->getSession(session_id);
-  if (!session) {
-    return makeVoidError(Error(jsonrpc::INVALID_PARAMS, "Session not found"));
-  }
-
   // Already on the dispatcher thread (e.g. called from a tool or request
-  // handler): deliver inline. The old post-and-wait here deadlocked the
-  // event loop — the future could only be fulfilled by the very thread
-  // that was blocked on it.
-  if (main_dispatcher_->isThreadSafe()) {
+  // handler): resolve and deliver inline, returning the real result. The
+  // old post-and-wait here deadlocked the event loop — the future could
+  // only be fulfilled by the very thread that was blocked on it.
+  if (main_dispatcher_ && main_dispatcher_->isThreadSafe()) {
+    auto session = session_manager_->getSession(session_id);
+    if (!session) {
+      return makeVoidError(Error(jsonrpc::INVALID_PARAMS, "Session not found"));
+    }
     return sendNotificationToSession(session, notification);
   }
 
-  // Off-thread caller (application thread): hop to the dispatcher and wait
-  // for the result. Safe because the dispatcher is free to run the task.
-  auto send_promise = std::make_shared<std::promise<VoidResult>>();
-  auto send_future = send_promise->get_future();
-  main_dispatcher_->post([this, session, notification, send_promise]() {
-    send_promise->set_value(sendNotificationToSession(session, notification));
+  if (!main_dispatcher_) {
+    return makeVoidError(Error(jsonrpc::INTERNAL_ERROR, "Server not running"));
+  }
+
+  // Off-thread caller (application thread). Resolve the session now (the
+  // lookup is mutex-guarded, so it is safe from any thread) purely to
+  // report an unknown id synchronously — the common misuse. Then hand the
+  // actual delivery to the dispatcher and return WITHOUT blocking on a
+  // result future. The previous post-and-wait hung forever if the
+  // dispatcher exited (shutdown) before running the task, since the promise
+  // would then never be fulfilled. A notification is one-way, so a
+  // fire-and-forget hand-off matching notifyResourceUpdate /
+  // broadcastNotification is the right contract: success means "accepted
+  // for delivery", not "delivered".
+  //
+  // The delivery task re-resolves the session by id rather than capturing
+  // the SessionPtr, so it never pins (or acts on) a session whose
+  // connection was freed between this call and the task running.
+  if (!session_manager_->getSession(session_id)) {
+    return makeVoidError(Error(jsonrpc::INVALID_PARAMS, "Session not found"));
+  }
+  main_dispatcher_->post([this, session_id, notification]() {
+    auto session = session_manager_->getSession(session_id);
+    if (session) {
+      sendNotificationToSession(session, notification);
+    }
   });
-  return send_future.get();
+  return makeVoidSuccess();
 }
 
 // Broadcast notification to all sessions

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -508,20 +508,26 @@ VoidResult McpServer::sendNotificationToSession(
               "SSE stream gone for session " + session->getId()));
   }
 
-  // Connection-keyed session (long-lived connection): write the JSON like
-  // the response path does and let the connection's filter chain frame it.
+  // Connection-keyed HTTP session: no valid server-initiated channel.
+  // HTTP/1.1 has no message outside a request/response cycle, so writing
+  // raw JSON to the connection would corrupt its framing. Such a session is
+  // also only ever an alias of an HTTP+SSE client whose real push channel
+  // is the SSE stream (the transport-keyed session above) — writing here
+  // too would duplicate the delivery. And on the posted off-thread path the
+  // connection may already be freed. So we deliberately do NOT write to
+  // session->getConnection(); we fail cleanly. (getConnection() is only
+  // compared to null here, never dereferenced, which is safe even if the
+  // pointer dangles.)
   if (session->getConnection()) {
-    auto json_val = json::to_json(notification);
-    std::string json_str = json_val.toString();
-    OwnedBuffer buffer;
-    buffer.add(json_str);
-    session->getConnection()->write(buffer, false);
-    return makeVoidSuccess();
+    return makeVoidError(
+        Error(jsonrpc::INTERNAL_ERROR,
+              "Session " + session->getId() +
+                  " has no server-initiated notification channel"));
   }
 
-  // Stdio: requests are dispatched without a connection pointer, so the
-  // session carries neither key. There is a single stdio client, reached
-  // through its connection manager.
+  // Neither key: stdio. Requests are dispatched without a connection
+  // pointer, so the session carries no key. There is a single stdio client,
+  // reached through its connection manager.
   for (auto& conn_manager : connection_managers_) {
     if (conn_manager->isConnected()) {
       return conn_manager->sendNotification(notification);
@@ -603,29 +609,25 @@ void McpServer::broadcastNotification(
     return;
   }
 
-  // Route per session so HTTP+SSE clients get their copy through their own
-  // SSE stream. Sessions with neither key share the single stdio client —
-  // send through the connection managers once, not once per session.
-  bool used_manager_fallback = false;
+  // Deliver to each client exactly once through its real push channel.
+  // Only two channels can carry a server-initiated message: an HTTP+SSE
+  // client's SSE stream (its transport-keyed session) and the stdio
+  // connection manager. Connection-keyed sessions are transient aliases of
+  // HTTP connections (the SSE GET stream, each one-shot POST) with no push
+  // channel of their own — enumerating them here is exactly what used to
+  // double-deliver to SSE clients and inject raw JSON into POST exchanges,
+  // so they are skipped.
   for (auto& session : session_manager_->getAllSessions()) {
-    const bool needs_manager_fallback =
-        session->getTransportSessionId().empty() && !session->getConnection();
-    if (needs_manager_fallback) {
-      if (used_manager_fallback) {
-        continue;
-      }
-      used_manager_fallback = true;
+    if (!session->getTransportSessionId().empty()) {
+      sendNotificationToSession(session, notification);
     }
-    sendNotificationToSession(session, notification);
   }
 
-  // A stdio client that has not sent a request yet has no session at all;
-  // preserve the old behavior of still broadcasting through the managers.
-  if (!used_manager_fallback) {
-    for (auto& conn_manager : connection_managers_) {
-      if (conn_manager->isConnected()) {
-        conn_manager->sendNotification(notification);
-      }
+  // stdio: a single client reached through its connection manager,
+  // independent of whether it has created a session yet.
+  for (auto& conn_manager : connection_managers_) {
+    if (conn_manager->isConnected()) {
+      conn_manager->sendNotification(notification);
     }
   }
 }

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -37,6 +37,19 @@ McpServer::McpServer(const McpServerConfig& config)
   // Initialize resource manager for resource handling
   resource_manager_ = std::make_unique<ResourceManager>(server_stats_);
 
+  // Release a session's resource subscriptions when the expiry sweep
+  // removes it. Without this, a timed-out session's ids would linger in the
+  // resource fan-out map forever (a slow leak, and a dead-id target for
+  // every future update). Runs on the dispatcher thread (the only caller of
+  // the sweep) with the SessionManager lock already released, so taking the
+  // ResourceManager lock here is safe. Connection-close and SSE-stream-close
+  // removals are handled separately by onConnectionLifecycleEvent and the
+  // registry's session-closed callback.
+  session_manager_->setSessionRemovedCallback(
+      [this](const SessionManager::SessionPtr& session) {
+        resource_manager_->releaseSession(*session);
+      });
+
   // Initialize tool registry for tool management
   tool_registry_ = std::make_unique<ToolRegistry>(server_stats_);
 

--- a/tests/integration/test_server_notification_delivery.cc
+++ b/tests/integration/test_server_notification_delivery.cc
@@ -485,5 +485,64 @@ TEST_F(ServerNotificationDeliveryTest, BroadcastDeliveredExactlyOnce) {
   EXPECT_EQ(count.load(), 1) << "broadcast delivered more than once";
 }
 
+
+// sendNotification from an application thread (off the dispatcher) must
+// deliver without blocking the caller and, crucially, must never hang: the
+// old post-and-wait blocked forever if the dispatcher exited before running
+// the task. Fire-and-forget removes that failure mode entirely.
+TEST_F(ServerNotificationDeliveryTest, SendNotificationOffThreadDelivers) {
+  std::promise<std::string> captured_session_id;
+  auto id_future = captured_session_id.get_future();
+  bool captured = false;
+  server_->registerRequestHandler(
+      "test/whoami",
+      [&captured_session_id, &captured](
+          const jsonrpc::Request& request,
+          server::SessionContext& session) -> jsonrpc::Response {
+        // Capture the server-side session id once so the test thread can
+        // target it with sendNotification.
+        if (!captured) {
+          captured = true;
+          captured_session_id.set_value(session.getId());
+        }
+        return jsonrpc::Response::success(
+            request.id, jsonrpc::ResponseResult(make<Metadata>().build()));
+      });
+
+  std::promise<std::string> delivered;
+  auto delivered_future = delivered.get_future();
+  auto* client = makeConnectedClient("offthread-client");
+  ASSERT_NE(client, nullptr);
+  client->registerNotificationHandler(
+      "test/offthread", [&delivered](const jsonrpc::Notification& n) {
+        std::string origin;
+        if (n.params.has_value()) {
+          auto it = n.params->find("origin");
+          if (it != n.params->end() &&
+              holds_alternative<std::string>(it->second)) {
+            origin = get<std::string>(it->second);
+          }
+        }
+        delivered.set_value(origin);
+      });
+
+  auto whoami = client->sendRequest("test/whoami");
+  ASSERT_EQ(whoami.wait_for(5s), std::future_status::ready);
+  ASSERT_EQ(id_future.wait_for(5s), std::future_status::ready);
+  const std::string session_id = id_future.get();
+
+  Metadata params;
+  params["origin"] = std::string("offthread");
+  jsonrpc::Notification pushed("test/offthread", params);
+
+  // Called on the test (application) thread — hits the off-dispatcher
+  // hand-off path. Returns "accepted for delivery" immediately.
+  auto result = server_->sendNotification(session_id, pushed);
+  EXPECT_TRUE(holds_alternative<std::nullptr_t>(result));
+
+  ASSERT_EQ(delivered_future.wait_for(5s), std::future_status::ready)
+      << "off-thread sendNotification never reached the client";
+  EXPECT_EQ(delivered_future.get(), "offthread");
+}
 }  // namespace
 }  // namespace mcp

--- a/tests/integration/test_server_notification_delivery.cc
+++ b/tests/integration/test_server_notification_delivery.cc
@@ -485,7 +485,6 @@ TEST_F(ServerNotificationDeliveryTest, BroadcastDeliveredExactlyOnce) {
   EXPECT_EQ(count.load(), 1) << "broadcast delivered more than once";
 }
 
-
 // sendNotification from an application thread (off the dispatcher) must
 // deliver without blocking the caller and, crucially, must never hang: the
 // old post-and-wait blocked forever if the dispatcher exited before running

--- a/tests/integration/test_server_notification_delivery.cc
+++ b/tests/integration/test_server_notification_delivery.cc
@@ -434,5 +434,56 @@ TEST_F(ServerNotificationDeliveryTest, DisconnectedSubscriberIsReleased) {
       << "remaining subscriber stopped receiving after peer disconnect";
 }
 
+// Regression for the double-delivery bug: an HTTP+SSE client is represented
+// by both its transport-keyed session and the connection-keyed session of
+// its SSE GET stream. Fan-out used to enumerate both and write to the same
+// stream twice. Here we COUNT deliveries and require exactly one — the
+// earlier tests could not catch a duplicate because the client swallows the
+// second handler invocation's exception.
+TEST_F(ServerNotificationDeliveryTest, ResourceUpdateDeliveredExactlyOnce) {
+  const std::string kUri = "test://resource/once";
+
+  std::atomic<int> count{0};
+  std::promise<void> first;
+  auto* client = makeConnectedClient("dedup-client");
+  ASSERT_NE(client, nullptr);
+  client->registerNotificationHandler(
+      "notifications/resources/updated",
+      [&count, &first](const jsonrpc::Notification&) {
+        if (++count == 1) {
+          first.set_value();
+        }
+      });
+
+  ASSERT_TRUE(subscribeAndWait(*client, kUri));
+  server_->notifyResourceUpdate(kUri);
+
+  ASSERT_EQ(first.get_future().wait_for(5s), std::future_status::ready)
+      << "update never delivered";
+  // Grace window for a stray duplicate to arrive before we assert none did.
+  std::this_thread::sleep_for(300ms);
+  EXPECT_EQ(count.load(), 1) << "resource update delivered more than once";
+}
+
+TEST_F(ServerNotificationDeliveryTest, BroadcastDeliveredExactlyOnce) {
+  std::atomic<int> count{0};
+  std::promise<void> first;
+  auto* client = makeConnectedClient("dedup-broadcast-client");
+  ASSERT_NE(client, nullptr);
+  client->registerNotificationHandler(
+      "test/broadcast", [&count, &first](const jsonrpc::Notification&) {
+        if (++count == 1) {
+          first.set_value();
+        }
+      });
+
+  server_->broadcastNotification(jsonrpc::Notification("test/broadcast"));
+
+  ASSERT_EQ(first.get_future().wait_for(5s), std::future_status::ready)
+      << "broadcast never delivered";
+  std::this_thread::sleep_for(300ms);
+  EXPECT_EQ(count.load(), 1) << "broadcast delivered more than once";
+}
+
 }  // namespace
 }  // namespace mcp

--- a/tests/server/test_session_transport_binding.cc
+++ b/tests/server/test_session_transport_binding.cc
@@ -114,9 +114,11 @@ TEST_F(SessionTransportBindingTest, RemoveSessionClearsTransportIndex) {
   EXPECT_EQ(manager.getSessionByTransportId("client_1"), nullptr);
 }
 
-// The expiry sweep must clean the transport index too, or an expired id
-// would keep resolving to a destroyed session.
-TEST_F(SessionTransportBindingTest, ExpirySweepCleansTransportIndex) {
+// Transport-keyed sessions are exempt from activity expiry: their lifetime
+// is bounded by the SSE stream closing, and an HTTP+SSE client may hold an
+// idle-but-open stream far longer than session_timeout. Expiring one would
+// silently drop a live client's session and leak its subscriptions.
+TEST_F(SessionTransportBindingTest, ExpirySweepSkipsTransportSessions) {
   config_.session_timeout = std::chrono::milliseconds(0);
   SessionManager manager(config_, stats_);
 
@@ -125,9 +127,59 @@ TEST_F(SessionTransportBindingTest, ExpirySweepCleansTransportIndex) {
 
   manager.cleanupExpiredSessions();
 
-  EXPECT_EQ(manager.getSessionByTransportId("client_1"), nullptr);
+  // Still there — only the SSE stream close (removeSessionByTransportId)
+  // may end a transport-keyed session.
+  EXPECT_EQ(manager.getSessionByTransportId("client_1"), session);
+  EXPECT_EQ(manager.getSession(session->getId()), session);
+  EXPECT_EQ(stats_.sessions_expired.load(), 0u);
+}
+
+// The expiry sweep fires the session-removed observer for each swept
+// (connection-keyed / stdio) session, so the server can release state it
+// keys on the session (resource subscriptions). Without it those entries
+// leak forever.
+TEST_F(SessionTransportBindingTest, ExpirySweepFiresRemovedCallback) {
+  config_.session_timeout = std::chrono::milliseconds(0);
+  SessionManager manager(config_, stats_);
+
+  std::vector<std::string> removed_ids;
+  manager.setSessionRemovedCallback(
+      [&removed_ids](const SessionManager::SessionPtr& s) {
+        removed_ids.push_back(s->getId());
+      });
+
+  auto session = manager.createSession(nullptr);
+  ASSERT_NE(session, nullptr);
+
+  manager.cleanupExpiredSessions();
+
   EXPECT_EQ(manager.getSession(session->getId()), nullptr);
-  EXPECT_EQ(stats_.sessions_expired.load(), 1u);
+  ASSERT_EQ(removed_ids.size(), 1u);
+  EXPECT_EQ(removed_ids[0], session->getId());
+}
+
+// The at-capacity sweep inside createSession also fires the observer for
+// the sessions it evicts.
+TEST_F(SessionTransportBindingTest, CapacitySweepFiresRemovedCallback) {
+  config_.max_sessions = 1;
+  config_.session_timeout = std::chrono::milliseconds(0);
+  SessionManager manager(config_, stats_);
+
+  std::vector<std::string> removed_ids;
+  manager.setSessionRemovedCallback(
+      [&removed_ids](const SessionManager::SessionPtr& s) {
+        removed_ids.push_back(s->getId());
+      });
+
+  auto first = manager.createSession(nullptr);
+  ASSERT_NE(first, nullptr);
+  // Second create trips the capacity sweep, which evicts the expired first
+  // session and fires the observer for it.
+  auto second = manager.createSession(nullptr);
+  ASSERT_NE(second, nullptr);
+
+  ASSERT_EQ(removed_ids.size(), 1u);
+  EXPECT_EQ(removed_ids[0], first->getId());
 }
 
 // The session limit covers transport-keyed sessions too, and rejection is


### PR DESCRIPTION
Follow-up to #261. A recall-biased code review of the merged notification-delivery work surfaced five confirmed correctness bugs; this PR fixes all five, each with a test that fails against the current `main`.

The root cause of three of them is one fact: `McpServer::onNewConnection` creates a **connection-keyed session for every accepted TCP connection**, including the SSE GET stream and each one-shot POST. So an HTTP+SSE client is represented by two sessions (its transport-keyed SSE session **and** the connection-keyed GET-stream session), and the fan-out paths iterated both.

## Bugs fixed

**1 + 4 — double-delivery and HTTP framing corruption** (`Route server notifications only to real push channels`)
`broadcastNotification`/`notifyResourceUpdate` enumerated `getAllSessions()` and delivered to both aliases of an HTTP+SSE client, writing to its SSE stream twice; the connection-keyed branch of `sendNotificationToSession` also wrote raw JSON to HTTP connections, corrupting the framing of any in-flight POST exchange (HTTP/1.1 has no message outside a request cycle). Unsolicited push is now routed only over real channels — an SSE stream (transport-keyed session) or the stdio manager — and connection-keyed sessions are skipped. The old tests couldn't catch the duplicate because the client swallows the second handler's exception; the new `DeliveredExactlyOnce` tests count deliveries and require exactly one.

**2 + 5 — use-after-free and shutdown hang in off-thread `sendNotification`** (`Make off-thread sendNotification fire-and-forget`)
The off-thread path posted a task and blocked on its result future: it hung forever if the dispatcher exited (shutdown) before running the task, and the task dereferenced a `SessionPtr` whose connection may already be freed (`SessionContext::connection_` is never nulled). It now reports an unknown id synchronously, then hands delivery to the dispatcher without waiting, re-resolving the session by id in the task.

**3 — resource subscriptions leak on session expiry** (`Release resource subscriptions when a session expires`)
The expiry sweep erased sessions but never released their subscriptions (SessionManager has no ResourceManager reference), so timed-out ids lingered in the fan-out map forever and an idle-but-connected HTTP+SSE client whose session was swept silently went dark. SessionManager now fires a session-removed observer (outside its lock) that McpServer wires to `releaseSession`, and transport-keyed sessions are exempt from activity expiry (their lifetime is the SSE stream).

## Tests

New/updated: `DeliveredExactlyOnce` (resource + broadcast), `SendNotificationOffThreadDelivers`, expiry-sweep and capacity-sweep observer firing, transport-keyed session survives expiry. Full suite (server/client/filter/integration) passes.

## Not addressed here (noted in review, larger scope)

- Config-driven listener path (`filter_chain_config`) doesn't set `http_sse_factory_`, so push is silently absent there — worth at least a warning; deeper fix is a session-owned notification sink.
- `current_transport_session_id_` as a second thread-global request context (fragile; a per-message dispatch context is the deeper fix).
- The factory keeping all filters alive for the connection's afterlife (the PR worked around the symptom).