### PR TITLE
Notification delivery: filter ownership, single-use binding, config-path honesty

### DIFF
--- a/include/mcp/filter/http_sse_filter_chain_factory.h
+++ b/include/mcp/filter/http_sse_filter_chain_factory.h
@@ -209,8 +209,12 @@ class HttpSseFilterChainFactory : public network::FilterChainFactory {
   // createFilterChain is const on the base class.
   mutable std::unique_ptr<SseSessionRegistry> sse_registry_;
 
-  // Store filters for lifetime management
-  mutable std::vector<network::FilterSharedPtr> filters_;
+  // NOTE: the factory intentionally does not retain the filters it creates.
+  // Each connection's FilterManager owns its own filter-chain instance for
+  // the connection's lifetime (per-connection ownership model), so a
+  // factory-held copy would only leak — keeping every connection's filters
+  // alive until the server shuts down and deferring the SSE-stream
+  // deregistration done in the filter destructor to that same late moment.
 
   // Filter factories added by user (authentication, logging, etc.)
   // These are invoked during chain creation to add filters before protocol

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -966,9 +966,11 @@ class McpServer : public application::ApplicationBase,
   // Request-scoped transport session binding. The transport filter announces
   // the transport-level session id (e.g. SSE stream id from the POST
   // /callback/{id} path) immediately before dispatching each message, on the
-  // dispatcher thread. Stored like current_connection_ as dispatch context;
-  // an empty id means the current message's transport has no session concept
-  // and session lookup falls back to connection identity.
+  // dispatcher thread. It is single-use: getOrCreateCurrentSession() consumes
+  // and clears it, so it applies only to the one message whose dispatch it
+  // preceded and a non-announcing producer can never inherit a stale id. An
+  // empty id means the current message's transport has no session concept and
+  // session lookup falls back to connection identity.
   void onTransportSessionBound(const std::string& transport_session_id) {
     current_transport_session_id_ = transport_session_id;
   }

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -1285,7 +1285,6 @@ bool HttpSseFilterChainFactory::createFilterChain(
       if (filter) {
         filter_manager.addReadFilter(filter);
         filter_manager.addWriteFilter(filter);
-        filters_.push_back(filter);
       }
     }
   }
@@ -1315,7 +1314,6 @@ bool HttpSseFilterChainFactory::createFilterChain(
     auto metrics_adapter = metrics_filter->createNetworkAdapter();
     filter_manager.addReadFilter(metrics_adapter);
     filter_manager.addWriteFilter(metrics_adapter);
-    filters_.push_back(metrics_adapter);
   }
 
   // Routing is now integrated into the combined filter
@@ -1338,12 +1336,16 @@ bool HttpSseFilterChainFactory::createFilterChain(
       use_sse_, route_registration_callback_, sse_path_, rpc_path_,
       external_url_, sse_registry_.get());
 
-  // Add as both read and write filter
+  // Add as both read and write filter. The FilterManager owns the filter
+  // for the connection's lifetime (per-connection filter ownership): when
+  // the connection is destroyed its FilterManager drops these refs and the
+  // filter destructs, which is what deregisters its SSE stream from the
+  // registry. The factory deliberately keeps NO reference of its own — a
+  // retained copy would keep every connection's filters (and their buffers)
+  // alive for the whole life of the server, and leave the filter destructor
+  // to run only at shutdown instead of at connection close.
   filter_manager.addReadFilter(combined_filter);
   filter_manager.addWriteFilter(combined_filter);
-
-  // Store for lifetime management
-  filters_.push_back(combined_filter);
 
   return true;
 }

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -226,6 +226,20 @@ void McpServer::performListen() {
         if (protocol_callbacks_) {
           tcp_listener->setProtocolCallbacks(*protocol_callbacks_);
         }
+
+        // The config-driven chain assembles named filters and does not build
+        // the SSE transport that owns the server->client push channel, so
+        // http_sse_factory_ stays null on this path. Warn once at setup so an
+        // operator relying on notifications/resources/updated (or any
+        // server-initiated notification) is not left debugging silent
+        // non-delivery — sendNotificationToSession reports the same reason
+        // per call, but the listener is where the capability is decided.
+        GOPHER_LOG_WARN(
+            "Config-driven listener '{}' does not provide a server-initiated "
+            "notification channel; resource-update and other server->client "
+            "notifications will not be delivered on this listener. Use the "
+            "built-in HTTP+SSE listener for server push.",
+            listener_config.name);
       } else {
         // Fallback to old constructor with default HTTP/SSE factory for
         // backward compatibility
@@ -506,15 +520,24 @@ VoidResult McpServer::sendNotificationToSession(
   // filter chain (the SSE codec frames it as a `data:` event). This is the
   // only channel that reaches an HTTP+SSE client outside a request cycle.
   if (!session->getTransportSessionId().empty()) {
-    if (http_sse_factory_) {
-      auto json_val = json::to_json(notification);
-      if (http_sse_factory_->sseRegistry().sendResponse(
-              session->getTransportSessionId(), json_val.toString())) {
-        return makeVoidSuccess();
-      }
+    // No SSE registry means this listener has no server-initiated push
+    // channel at all — the config-driven filter-chain path does not build
+    // the SSE transport (see performListen). Distinguish that from a stream
+    // that merely closed, so the failure is diagnosable rather than looking
+    // like a transient disconnect.
+    if (!http_sse_factory_) {
+      return makeVoidError(
+          Error(jsonrpc::INTERNAL_ERROR,
+                "No server-initiated notification channel on this listener "
+                "(server push requires the built-in HTTP+SSE listener)"));
     }
-    // Stream already gone (client disconnected between lookup and send) or
-    // no HTTP factory — report failure so the caller doesn't assume
+    auto json_val = json::to_json(notification);
+    if (http_sse_factory_->sseRegistry().sendResponse(
+            session->getTransportSessionId(), json_val.toString())) {
+      return makeVoidSuccess();
+    }
+    // Registry exists but the stream is gone (client disconnected between
+    // lookup and send) — report failure so the caller doesn't assume
     // delivery.
     return makeVoidError(
         Error(jsonrpc::INTERNAL_ERROR,

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -735,16 +735,27 @@ void McpServer::setupFilterChain(application::FilterChainBuilder& builder) {
 }
 
 SessionManager::SessionPtr McpServer::getOrCreateCurrentSession() {
+  // The transport session binding is strictly single-use: consume it here
+  // and clear it immediately, so it can only ever apply to the one message
+  // whose dispatch it preceded. The transport filter announces it (via
+  // onTransportSessionBound) right before onRequest/onNotification, but a
+  // producer that does NOT announce — stdio, or any non-SSE filter chain —
+  // must not inherit the previous message's id. Clearing on consume makes a
+  // stale binding unrepresentable rather than relying on every producer to
+  // remember to announce an empty id. Dispatch is synchronous per message
+  // on the dispatcher thread, so consume-and-clear is race-free.
+  std::string transport_session_id;
+  transport_session_id.swap(current_transport_session_id_);
+
   // Transport session id wins: for HTTP+SSE each request arrives on a
   // one-shot POST connection, so keying the session on the connection
   // would hand every request a fresh session and silently drop state
-  // such as resource subscriptions. The SSE stream id announced by the
-  // transport filter is the identity that actually spans the client's
-  // requests — and it is also what the push path needs to find the
-  // client's SSE stream.
-  if (!current_transport_session_id_.empty()) {
+  // such as resource subscriptions. The SSE stream id is the identity that
+  // actually spans the client's requests — and it is also what the push
+  // path needs to find the client's SSE stream.
+  if (!transport_session_id.empty()) {
     return session_manager_->getOrCreateSessionByTransportId(
-        current_transport_session_id_);
+        transport_session_id);
   }
 
   // Connection-keyed fallback for transports where the connection is

--- a/tests/integration/test_http_sse_filter_server_mode.cc
+++ b/tests/integration/test_http_sse_filter_server_mode.cc
@@ -23,6 +23,7 @@
 
 #include "mcp/buffer.h"
 #include "mcp/filter/http_sse_filter_chain_factory.h"
+#include "mcp/filter/sse_session_registry.h"
 #include "mcp/mcp_connection_manager.h"
 #include "mcp/network/connection_impl.h"
 #include "mcp/network/socket_impl.h"
@@ -399,6 +400,61 @@ TEST_F(ServerModeFilterTest, ConnectionClose_NoHangOrCrash) {
   // Clean shutdown — no hang, no crash
   closeOnDispatcher(std::move(conn), std::move(factory));
   SUCCEED();
+}
+
+// ── Filter lifetime is bounded by the connection ──────────────────
+
+// The factory must NOT retain the filters it builds: each connection's
+// FilterManager owns its filter chain, so destroying the connection alone
+// must destruct the combined filter, whose destructor deregisters the SSE
+// stream from the registry. We open an SSE stream, then destroy ONLY the
+// connection (the factory stays alive) and require the registry entry to be
+// gone. If the factory still held the filter, its destructor would not run
+// and the entry would leak.
+TEST_F(ServerModeFilterTest, ConnectionDestroyReleasesFilterAndSseStream) {
+  ServerModeCallbacks callbacks;
+  std::unique_ptr<network::ServerConnection> conn;
+  network::IoHandlePtr peer;
+  std::shared_ptr<HttpSseFilterChainFactory> factory;
+
+  executeInDispatcher([&]() {
+    auto h = makeServerHarness(callbacks);
+    conn = std::move(h.conn);
+    peer = std::move(h.peer);
+    factory = std::move(h.factory);
+
+    writeClientBytes(*peer,
+                     "GET /sse HTTP/1.1\r\n"
+                     "Host: localhost\r\n"
+                     "Accept: text/event-stream\r\n"
+                     "\r\n");
+  });
+
+  // The endpoint event proves the stream registered.
+  std::string wire = drainPeer(*peer, 500ms);
+  ASSERT_NE(wire.find("event: endpoint"), std::string::npos)
+      << "SSE stream never opened, got: " << wire;
+
+  size_t after_open = 0;
+  executeInDispatcher(
+      [&]() { after_open = factory->sseRegistry().sessionCount(); });
+  ASSERT_EQ(after_open, 1u) << "GET /sse should register exactly one stream";
+
+  // Destroy ONLY the connection (keep the factory alive). With the factory
+  // no longer retaining the filter, this drops the last reference, runs the
+  // combined filter's destructor, and deregisters the stream.
+  size_t after_close = 99;
+  executeInDispatcher([&]() {
+    conn->close(network::ConnectionCloseType::NoFlush);
+    conn.reset();
+    after_close = factory->sseRegistry().sessionCount();
+  });
+  EXPECT_EQ(after_close, 0u)
+      << "destroying the connection must destruct its filter and deregister "
+         "the SSE stream — a non-zero count means the factory leaked the "
+         "filter past the connection's lifetime";
+
+  executeInDispatcher([&]() { factory.reset(); });
 }
 
 }  // namespace


### PR DESCRIPTION
Follow-up to #262, addressing the three architectural items called out there as "not addressed here (larger scope)". Each was checked against the network-filter subsystem's reference design before implementing.

## 1. Own filters per-connection via FilterManager, not the factory

`HttpSseFilterChainFactory` retained a `shared_ptr` to every filter it built in a `filters_` vector for the factory's whole lifetime. Because an HTTP+SSE client sends each request on a one-shot POST connection, this leaked ~3 filter objects (plus buffers) per request until shutdown, and deferred the combined filter's destructor — which deregisters the SSE stream — to that same late moment.

The vector was write-only: every filter was also installed into the connection's `FilterManager` via `addReadFilter`/`addWriteFilter`, which is the per-connection owner (the connection owns its `FilterManager` by value; factory callbacks install into the manager and retain nothing). Dropping `filters_` makes filter lifetime equal connection lifetime; the SSE-stream deregistration now runs in the filter destructor at connection close, and the registry `removeConnection` sweep becomes a pure backstop.

**Test:** open an SSE stream, then destroy only the connection (factory kept alive) → registry entry drops to zero, proving the filter destructed with its connection rather than lingering in the factory.

## 2. Make the transport session binding strictly single-use

`current_transport_session_id_` was an ambient dispatch-context member overwritten on each announcement but never cleared after use — the anti-pattern of reading per-request identity from a connection-scoped global. A producer that never announces (stdio, any non-SSE chain) could resolve a message against a previous message's id. `getOrCreateCurrentSession` now swaps the id into a local and clears the member as it consumes it, so a stale binding is unrepresentable. Per-message consume correctness is already covered by the multi-client delivery tests; the remaining guarantee needs two transports in one instance, which isn't currently constructible.

## 3. Surface that config-driven listeners have no server-push channel

The config-driven filter-chain path never builds the SSE transport, so `http_sse_factory_` stays null and server-initiated notifications were dropped with a misleading "SSE stream gone". `performListen` now warns at the point the capability is decided, and `sendNotificationToSession` distinguishes "no channel configured" from "stream closed". Honest failure reporting, not new capability — SSE push on the config-driven chain is separate, larger work.

## Tests
Full server/client/filter/integration suite passes; new filter-lifetime test added.