### PR TITLE
Harden the dispatch-context routing paths (#265)

### DIFF
--- a/include/mcp/filter/circuit_breaker_filter.h
+++ b/include/mcp/filter/circuit_breaker_filter.h
@@ -127,33 +127,25 @@ class CircuitBreakerFilter : public network::NetworkFilterBase,
 
   // JsonRpcProtocolFilter::MessageHandler implementation
   void onRequest(const jsonrpc::Request& request) override {
-    std::lock_guard<std::mutex> lock(mutex_);
+    if (!admitRequest(request)) {
+      // No reply path on the context-free entry: block silently, as this
+      // filter always has.
+      return;
+    }
 
-    // TEMPORARY DEBUG: Verify filter is being called
-    std::cout << "[CIRCUIT_BREAKER] onRequest called: method=" << request.method
-              << " state=" << stateToString(state_) << std::endl;
+    // Forward request. The admission lock is released before forwarding so
+    // downstream dispatch never runs under this filter's mutex.
+    if (next_callbacks_) {
+      next_callbacks_->onRequest(request);
+    }
+  }
 
-    GOPHER_LOG(Debug, "onRequest: method=%s id=%s circuit_state=%s",
-               request.method.c_str(), requestIdToString(request.id).c_str(),
-               stateToString(state_));
-
-    // Check circuit state
-    if (!allowRequest(request.method)) {
-      // Circuit is open - fail fast
-      std::cout << "[CIRCUIT_BREAKER] ⛔ REQUEST BLOCKED: " << request.method
-                << std::endl;
-      if (emitter_) {
-        std::cout
-            << "[CIRCUIT_BREAKER] 📡 Emitting CIRCUIT_REQUEST_BLOCKED event"
-            << std::endl;
-        json::JsonObjectBuilder event_data;
-        event_data.add("method", request.method);
-        event_data.add("state", stateToString(state_));
-        emitter_->emit(FilterEventType::CIRCUIT_REQUEST_BLOCKED,
-                       FilterEventSeverity::WARN, event_data.build());
-      }
-
-      // Send error response
+  void onRequestWithContext(const jsonrpc::Request& request,
+                            MessageDispatchContext& context) override {
+    if (!admitRequest(request)) {
+      // The dispatch context supplies the reply path the context-free
+      // entry never had: fail fast to the client instead of letting the
+      // blocked request time out silently.
       jsonrpc::Response error_response;
       error_response.jsonrpc = "2.0";
       error_response.id = request.id;
@@ -161,19 +153,12 @@ class CircuitBreakerFilter : public network::NetworkFilterBase,
       error.data = mcp::make_optional(ErrorData(
           std::map<std::string, std::string>{{"circuit_state", "open"}}));
       error_response.error = mcp::make_optional(error);
-
-      // Would need write callbacks to send this
-      // For now, just block the request
+      context.sendResponse(error_response);
       return;
     }
 
-    // Track request start time
-    pending_requests_[requestIdToString(request.id)] = {
-        request.method, std::chrono::steady_clock::now()};
-
-    // Forward request
     if (next_callbacks_) {
-      next_callbacks_->onRequest(request);
+      next_callbacks_->onRequestWithContext(request, context);
     }
   }
 
@@ -241,6 +226,15 @@ class CircuitBreakerFilter : public network::NetworkFilterBase,
     }
   }
 
+  void onNotificationWithContext(const jsonrpc::Notification& notification,
+                                 MessageDispatchContext& context) override {
+    // Notifications don't affect circuit breaker; preserve the per-message
+    // context across the hop.
+    if (next_callbacks_) {
+      next_callbacks_->onNotificationWithContext(notification, context);
+    }
+  }
+
   void onProtocolError(const Error& error) override {
     std::lock_guard<std::mutex> lock(mutex_);
 
@@ -287,6 +281,47 @@ class CircuitBreakerFilter : public network::NetworkFilterBase,
     bool success;
     uint64_t latency_ms;
   };
+
+  // Admission control shared by both dispatch entries so they can never
+  // drift: checks circuit state, emits the blocked event, and tracks the
+  // pending request under the mutex. Returns false when the circuit is
+  // open and the request must not be forwarded; the caller decides how to
+  // fail (silent block vs error reply through the dispatch context). The
+  // lock is scoped here so downstream forwarding runs without it.
+  bool admitRequest(const jsonrpc::Request& request) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // TEMPORARY DEBUG: Verify filter is being called
+    std::cout << "[CIRCUIT_BREAKER] onRequest called: method=" << request.method
+              << " state=" << stateToString(state_) << std::endl;
+
+    GOPHER_LOG(Debug, "onRequest: method=%s id=%s circuit_state=%s",
+               request.method.c_str(), requestIdToString(request.id).c_str(),
+               stateToString(state_));
+
+    // Check circuit state
+    if (!allowRequest(request.method)) {
+      // Circuit is open - fail fast
+      std::cout << "[CIRCUIT_BREAKER] ⛔ REQUEST BLOCKED: " << request.method
+                << std::endl;
+      if (emitter_) {
+        std::cout
+            << "[CIRCUIT_BREAKER] 📡 Emitting CIRCUIT_REQUEST_BLOCKED event"
+            << std::endl;
+        json::JsonObjectBuilder event_data;
+        event_data.add("method", request.method);
+        event_data.add("state", stateToString(state_));
+        emitter_->emit(FilterEventType::CIRCUIT_REQUEST_BLOCKED,
+                       FilterEventSeverity::WARN, event_data.build());
+      }
+      return false;
+    }
+
+    // Track request start time
+    pending_requests_[requestIdToString(request.id)] = {
+        request.method, std::chrono::steady_clock::now()};
+    return true;
+  }
 
   bool allowRequest(const std::string& method) {
     auto now = std::chrono::steady_clock::now();

--- a/include/mcp/filter/http_sse_filter_chain_factory.h
+++ b/include/mcp/filter/http_sse_filter_chain_factory.h
@@ -165,15 +165,6 @@ class HttpSseFilterChainFactory : public network::FilterChainFactory {
   }
 
   /**
-   * Send a response through the connection's filter chain
-   * Following production pattern: connection context flows through
-   * @param response The JSON-RPC response to send
-   * @param connection The connection to send the response on
-   */
-  static void sendHttpResponse(const jsonrpc::Response& response,
-                               network::Connection& connection);
-
-  /**
    * Access the server-side SSE session registry, creating it on first use
    * (same lazy construction createFilterChain performs). This is the
    * server layer's handle for two things it cannot do from inside a

--- a/include/mcp/filter/metrics_filter.h
+++ b/include/mcp/filter/metrics_filter.h
@@ -138,6 +138,15 @@ class MetricsFilter : public JsonRpcProtocolFilter::MessageHandler,
   void onNotification(const jsonrpc::Notification& notification) override;
   void onResponse(const jsonrpc::Response& response) override;
   void onProtocolError(const Error& error) override;
+  /**
+   * Context-carrying variants: record the same metrics, then forward the
+   * per-message context so a chain spliced through this filter does not
+   * silently degrade the application layer to its context-free path.
+   */
+  void onRequestWithContext(const jsonrpc::Request& request,
+                            MessageDispatchContext& context) override;
+  void onNotificationWithContext(const jsonrpc::Notification& notification,
+                                 MessageDispatchContext& context) override;
 
   /** Chain to the next message handler */
   void setNextCallbacks(JsonRpcProtocolFilter::MessageHandler* callbacks);
@@ -150,6 +159,10 @@ class MetricsFilter : public JsonRpcProtocolFilter::MessageHandler,
 
   void initializeMetricsState();
   void resetConnectionMetrics();
+  // Metric recording shared by the context-free and context-carrying
+  // dispatch entries, so the two can never drift.
+  void recordRequestMetrics(const jsonrpc::Request& request);
+  void recordNotificationMetrics(const jsonrpc::Notification& notification);
   void updateReceiveRate(size_t bytes);
   void updateSendRate(size_t bytes);
   void updateLatencyMetrics(uint64_t latency_ms);
@@ -305,7 +318,8 @@ inline void MetricsFilter::recordOutgoingBytes(size_t bytes) {
   updateSendRate(bytes);
 }
 
-inline void MetricsFilter::onRequest(const jsonrpc::Request& request) {
+inline void MetricsFilter::recordRequestMetrics(
+    const jsonrpc::Request& request) {
   metrics_.requests_received++;
   recordActivity();
 
@@ -320,13 +334,26 @@ inline void MetricsFilter::onRequest(const jsonrpc::Request& request) {
     pending_requests_[requestIdToString(request.id)] =
         std::chrono::steady_clock::now();
   }
+}
+
+inline void MetricsFilter::onRequest(const jsonrpc::Request& request) {
+  recordRequestMetrics(request);
 
   if (next_callbacks_) {
     next_callbacks_->onRequest(request);
   }
 }
 
-inline void MetricsFilter::onNotification(
+inline void MetricsFilter::onRequestWithContext(
+    const jsonrpc::Request& request, MessageDispatchContext& context) {
+  recordRequestMetrics(request);
+
+  if (next_callbacks_) {
+    next_callbacks_->onRequestWithContext(request, context);
+  }
+}
+
+inline void MetricsFilter::recordNotificationMetrics(
     const jsonrpc::Notification& notification) {
   metrics_.notifications_received++;
   recordActivity();
@@ -335,9 +362,24 @@ inline void MetricsFilter::onNotification(
     std::lock_guard<std::mutex> lock(method_mutex_);
     metrics_.method_counts[notification.method]++;
   }
+}
+
+inline void MetricsFilter::onNotification(
+    const jsonrpc::Notification& notification) {
+  recordNotificationMetrics(notification);
 
   if (next_callbacks_) {
     next_callbacks_->onNotification(notification);
+  }
+}
+
+inline void MetricsFilter::onNotificationWithContext(
+    const jsonrpc::Notification& notification,
+    MessageDispatchContext& context) {
+  recordNotificationMetrics(notification);
+
+  if (next_callbacks_) {
+    next_callbacks_->onNotificationWithContext(notification, context);
   }
 }
 

--- a/include/mcp/filter/request_logger_filter.h
+++ b/include/mcp/filter/request_logger_filter.h
@@ -59,6 +59,13 @@ class RequestLoggerFilter : public network::NetworkFilterBase,
   // JsonRpcProtocolFilter::MessageHandler overrides
   void onRequest(const jsonrpc::Request& request) override;
   void onNotification(const jsonrpc::Notification& notification) override;
+  // Context-carrying variants: log identically, then forward the
+  // per-message context so a chain spliced through this filter does not
+  // silently degrade the application layer to its context-free path.
+  void onRequestWithContext(const jsonrpc::Request& request,
+                            MessageDispatchContext& context) override;
+  void onNotificationWithContext(const jsonrpc::Notification& notification,
+                                 MessageDispatchContext& context) override;
   void onResponse(const jsonrpc::Response& response) override;
   void onProtocolError(const Error& error) override;
 
@@ -70,6 +77,11 @@ class RequestLoggerFilter : public network::NetworkFilterBase,
   void setNextCallbacks(JsonRpcProtocolFilter::MessageHandler* callbacks);
 
  private:
+  // Logging shared by the context-free and context-carrying dispatch
+  // entries, so the two can never drift.
+  void logRequest(const jsonrpc::Request& request);
+  void logNotification(const jsonrpc::Notification& notification);
+
   void logJsonRpcMessage(const std::string& message_type,
                          MessageDirection direction,
                          const std::string& summary,

--- a/include/mcp/filter/request_validation_filter.h
+++ b/include/mcp/filter/request_validation_filter.h
@@ -159,6 +159,29 @@ class RequestValidationFilter : public network::NetworkFilterBase,
     }
   }
 
+  // Context-carrying variants: validate identically, then forward the
+  // per-message context so a chain spliced through this filter does not
+  // silently degrade the application layer to its context-free path.
+  void onRequestWithContext(const jsonrpc::Request& request,
+                            MessageDispatchContext& context) override {
+    if (!validateRequest(request)) {
+      return;
+    }
+    if (next_callbacks_) {
+      next_callbacks_->onRequestWithContext(request, context);
+    }
+  }
+
+  void onNotificationWithContext(const jsonrpc::Notification& notification,
+                                 MessageDispatchContext& context) override {
+    if (!validateNotification(notification)) {
+      return;
+    }
+    if (next_callbacks_) {
+      next_callbacks_->onNotificationWithContext(notification, context);
+    }
+  }
+
   void onResponse(const jsonrpc::Response& response) override {
     // Responses typically don't need validation in server context
     // Just forward them

--- a/include/mcp/mcp_connection_manager.h
+++ b/include/mcp/mcp_connection_manager.h
@@ -183,6 +183,16 @@ class McpConnectionManager : public McpProtocolCallbacks,
   bool isConnected() const;
 
   /**
+   * True when this manager's transport owns the given connection. Session-
+   * targeted server pushes use this to route a connection-keyed session
+   * (stdio: the dispatch context keys the session on the pipe connection)
+   * back through the manager that can frame and write on that transport.
+   */
+  bool ownsConnection(const network::Connection* connection) const {
+    return connection != nullptr && active_connection_.get() == connection;
+  }
+
+  /**
    * Set protocol callbacks
    */
   void setProtocolCallbacks(McpProtocolCallbacks& callbacks) {

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -86,6 +86,12 @@ struct McpServerConfig : public application::ApplicationBase::Config {
   std::vector<TransportType> supported_transports = {TransportType::Stdio,
                                                      TransportType::HttpSse};
 
+  // Optional override for the stdio transport's socket configuration.
+  // Defaults to the process's real stdin/stdout; embedders and tests point
+  // it at pipe fds instead (with use_bridge=false) to drive a stdio server
+  // in-process.
+  optional<transport::StdioTransportSocketConfig> stdio_transport_config;
+
   // HTTP/SSE specific configuration
   std::string http_rpc_path = "/rpc";        // Path for JSON-RPC over HTTP
   std::string http_sse_path = "/sse";        // Path for SSE event stream

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -1014,6 +1014,18 @@ class McpServer : public application::ApplicationBase,
   // fall back to the first connected stdio manager. Defined in the .cc.
   class LegacyDispatchContext;
 
+  // The single shared session for context-free dispatches. A null-keyed
+  // session is unretrievable by any lookup, so creating one per message
+  // would leak sessions until max_sessions starves every transport;
+  // reusing one also preserves a legacy client's state across messages.
+  // Dispatcher thread only.
+  SessionManager::SessionPtr legacy_session_;
+
+  // The context-free dispatch warning fires once per server, not per
+  // message: a legacy producer emits it on every single message, which is
+  // log flooding, not signal. Dispatcher thread only.
+  bool legacy_dispatch_warned_{false};
+
   // Deliver a notification to one session's client, routed by how the
   // session is keyed: SSE stream (via the registry), owning connection,
   // or the stdio connection manager. Dispatcher thread only.

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -1291,23 +1291,6 @@ class HttpSseJsonRpcProtocolFilter
   HttpRouteRegistrationCallback route_registration_callback_;
 };
 
-// Static method to send response through the connection's filter chain
-// Following production pattern: ensure execution in the connection's dispatcher
-// thread
-void HttpSseFilterChainFactory::sendHttpResponse(
-    const jsonrpc::Response& response, network::Connection& connection) {
-  GOPHER_LOG_WARN(
-      "HttpSseFilterChainFactory::sendHttpResponse called but filter "
-      "access not available");
-  GOPHER_LOG_WARN("Response ID {} dropped - no direct filter access",
-                  requestIdToString(response.id));
-
-  // Following production pattern: without direct filter access, we cannot route
-  // responses The proper solution is for the connection manager to maintain
-  // filter references and provide a proper API for response routing. For now,
-  // responses must be sent through the connection manager's own mechanisms.
-}
-
 // ===== Factory Implementation =====
 
 HttpSseFilterChainFactory::HttpSseFilterChainFactory(

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -1015,9 +1015,17 @@ class HttpSseJsonRpcProtocolFilter
     DispatchContext context(*this);
     mcp_callbacks_.onNotificationWithContext(notification, context);
 
-    // For HTTP transport, send HTTP 202 Accepted response
-    // JSON-RPC notifications don't have responses, but HTTP requires one
-    if (is_server_ && write_callbacks_) {
+    // For HTTP transport, send HTTP 202 Accepted response.
+    // JSON-RPC notifications don't have responses, but HTTP requires one.
+    //
+    // NOT in callback-proxy mode, for two reasons: onHeaders already
+    // answered the POST /callback with a guarded 202 at header time, and
+    // this write is unguarded — onWrite's callback-proxy branch would
+    // capture the raw status line and ship it down the client's SSE
+    // stream as event data, corrupting the stream with
+    // "data: HTTP/1.1 202 Accepted...".
+    if (is_server_ && write_callbacks_ &&
+        !(server_mode_ && server_mode_->isCallbackProxy())) {
       // Build minimal HTTP 202 response
       std::string http_response =
           "HTTP/1.1 202 Accepted\r\n"

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -955,8 +955,12 @@ class HttpSseJsonRpcProtocolFilter
 
     VoidResult sendResponse(const jsonrpc::Response& response) override {
       // Fail loudly when the reply path is gone instead of pretending the
-      // response went out.
-      if (!parent_.write_callbacks_) {
+      // response went out. The state check matters as much as the null
+      // check: write_callbacks_ is never cleared, and a write to a
+      // non-open connection is silently discarded by the connection.
+      if (!parent_.write_callbacks_ ||
+          parent_.write_callbacks_->connection().state() !=
+              network::ConnectionState::Open) {
         Error err;
         err.code = jsonrpc::INTERNAL_ERROR;
         err.message = "response dropped: origin connection is gone";

--- a/src/filter/json_rpc_protocol_filter.cc
+++ b/src/filter/json_rpc_protocol_filter.cc
@@ -211,9 +211,14 @@ class JsonRpcProtocolFilter::DispatchContextImpl
   }
 
   VoidResult sendResponse(const jsonrpc::Response& response) override {
-    // Fail loudly when the reply path is gone: a null result here would
-    // otherwise read as "sent" to the caller while nothing went out.
-    if (!parent_.write_callbacks_) {
+    // Fail loudly when the reply path is gone. The null check alone is not
+    // enough: write_callbacks_ is set once at chain init and never cleared,
+    // while ConnectionImpl::write on a non-open connection silently returns
+    // — so without the state check a reply to a client that already hung up
+    // would report success while nothing went out.
+    if (!parent_.write_callbacks_ ||
+        parent_.write_callbacks_->connection().state() !=
+            network::ConnectionState::Open) {
       Error err;
       err.code = jsonrpc::INTERNAL_ERROR;
       err.message = "response dropped: origin connection is gone";

--- a/src/filter/json_rpc_protocol_filter.cc
+++ b/src/filter/json_rpc_protocol_filter.cc
@@ -71,6 +71,22 @@ class ProtocolCallbackBridge : public JsonRpcProtocolFilter::MessageHandler {
     callbacks_.onError(error);
   }
 
+  // Propagate the per-message origin so config-driven chains (which install
+  // this bridge via the FilterCreationContext constructor) reply on the
+  // connection the message arrived on. Without these overrides the default
+  // forwarding strips the context and the application layer falls onto its
+  // degraded context-free path — on a listener-only server that means the
+  // reply is never written at all.
+  void onRequestWithContext(const jsonrpc::Request& request,
+                            MessageDispatchContext& context) override {
+    callbacks_.onRequestWithContext(request, context);
+  }
+
+  void onNotificationWithContext(const jsonrpc::Notification& notification,
+                                 MessageDispatchContext& context) override {
+    callbacks_.onNotificationWithContext(notification, context);
+  }
+
  private:
   McpProtocolCallbacks& callbacks_;
 };

--- a/src/filter/request_logger_filter.cc
+++ b/src/filter/request_logger_filter.cc
@@ -104,7 +104,7 @@ RequestLoggerFilter::~RequestLoggerFilter() {
   std::cout << "✅ [RequestLogger] Destructor completed" << std::endl;
 }
 
-void RequestLoggerFilter::onRequest(const jsonrpc::Request& request) {
+void RequestLoggerFilter::logRequest(const jsonrpc::Request& request) {
   // DEBUG TRACE
   std::cout << "\n🟢 [RequestLogger] onRequest() ENTRY" << std::endl;
   std::cout << "   Method: " << request.method << std::endl;
@@ -120,16 +120,30 @@ void RequestLoggerFilter::onRequest(const jsonrpc::Request& request) {
 
   std::cout << "✅ [RequestLogger] Request logged, propagating to next handler"
             << std::endl;
+}
+
+void RequestLoggerFilter::onRequest(const jsonrpc::Request& request) {
+  logRequest(request);
 
   if (next_callbacks_) {
     next_callbacks_->onRequest(request);
   } else {
-    std::cout << "⚠️  [RequestLogger] No next handler registered!"
-              << std::endl;
+    std::cout << "⚠️  [RequestLogger] No next handler registered!" << std::endl;
   }
 }
 
-void RequestLoggerFilter::onNotification(
+void RequestLoggerFilter::onRequestWithContext(
+    const jsonrpc::Request& request, MessageDispatchContext& context) {
+  logRequest(request);
+
+  if (next_callbacks_) {
+    next_callbacks_->onRequestWithContext(request, context);
+  } else {
+    std::cout << "⚠️  [RequestLogger] No next handler registered!" << std::endl;
+  }
+}
+
+void RequestLoggerFilter::logNotification(
     const jsonrpc::Notification& notification) {
   // DEBUG TRACE
   std::cout << "\n🟢 [RequestLogger] onNotification() ENTRY" << std::endl;
@@ -141,9 +155,24 @@ void RequestLoggerFilter::onNotification(
   json::JsonValue payload = json::to_json(notification);
   logJsonRpcMessage("notification", MessageDirection::Outgoing, summary.str(),
                     payload);
+}
+
+void RequestLoggerFilter::onNotification(
+    const jsonrpc::Notification& notification) {
+  logNotification(notification);
 
   if (next_callbacks_) {
     next_callbacks_->onNotification(notification);
+  }
+}
+
+void RequestLoggerFilter::onNotificationWithContext(
+    const jsonrpc::Notification& notification,
+    MessageDispatchContext& context) {
+  logNotification(notification);
+
+  if (next_callbacks_) {
+    next_callbacks_->onNotificationWithContext(notification, context);
   }
 }
 
@@ -168,8 +197,7 @@ void RequestLoggerFilter::onResponse(const jsonrpc::Response& response) {
   if (next_callbacks_) {
     next_callbacks_->onResponse(response);
   } else {
-    std::cout << "⚠️  [RequestLogger] No next handler registered!"
-              << std::endl;
+    std::cout << "⚠️  [RequestLogger] No next handler registered!" << std::endl;
   }
 }
 
@@ -193,8 +221,7 @@ void RequestLoggerFilter::onProtocolError(const Error& error) {
   if (next_callbacks_) {
     next_callbacks_->onProtocolError(error);
   } else {
-    std::cout << "⚠️  [RequestLogger] No next handler registered!"
-              << std::endl;
+    std::cout << "⚠️  [RequestLogger] No next handler registered!" << std::endl;
   }
 }
 

--- a/src/filter/stdio_filter_chain_factory.cc
+++ b/src/filter/stdio_filter_chain_factory.cc
@@ -6,51 +6,23 @@
 
 #include "mcp/filter/stdio_filter_chain_factory.h"
 
+// DirectJsonRpcCallbacks lives in json_rpc_filter_factory.h. This file
+// used to define its own namespace-scope class with the SAME name — an
+// ODR violation: two translation units emitted the same mangled class
+// with (after the context hooks landed) different vtable layouts, which
+// a linker is free to merge into misrouted virtual calls. Reuse the one
+// public definition instead.
+#include "mcp/filter/json_rpc_filter_factory.h"
 #include "mcp/filter/json_rpc_protocol_filter.h"
 
 namespace mcp {
 namespace filter {
 
-/**
- * Direct callbacks adapter for JSON-RPC to MCP
- * Simply forwards JSON-RPC messages to MCP callbacks
- */
-class DirectJsonRpcCallbacks : public JsonRpcProtocolFilter::MessageHandler {
- public:
-  DirectJsonRpcCallbacks(McpProtocolCallbacks& mcp_callbacks)
-      : mcp_callbacks_(mcp_callbacks) {}
-
-  void onRequest(const jsonrpc::Request& request) override {
-    mcp_callbacks_.onRequest(request);
-  }
-
-  void onNotification(const jsonrpc::Notification& notification) override {
-    mcp_callbacks_.onNotification(notification);
-  }
-
-  // Propagate the per-message origin built by the JSON-RPC filter so the
-  // application layer can reply on the connection the message arrived on.
-  void onRequestWithContext(const jsonrpc::Request& request,
-                            MessageDispatchContext& context) override {
-    mcp_callbacks_.onRequestWithContext(request, context);
-  }
-
-  void onNotificationWithContext(const jsonrpc::Notification& notification,
-                                 MessageDispatchContext& context) override {
-    mcp_callbacks_.onNotificationWithContext(notification, context);
-  }
-
-  void onResponse(const jsonrpc::Response& response) override {
-    mcp_callbacks_.onResponse(response);
-  }
-
-  void onProtocolError(const Error& error) override {
-    mcp_callbacks_.onError(error);
-  }
-
- private:
-  McpProtocolCallbacks& mcp_callbacks_;
-};
+// Anonymous namespace: this wrapper is an implementation detail of the
+// stdio factory; internal linkage keeps any future same-named class in
+// another translation unit from colliding the way DirectJsonRpcCallbacks
+// did.
+namespace {
 
 /**
  * Wrapper filter that owns the callbacks adapter
@@ -98,6 +70,8 @@ class StdioJsonRpcFilterWrapper : public network::NetworkFilterBase {
   std::shared_ptr<DirectJsonRpcCallbacks> callbacks_adapter_;
   std::shared_ptr<JsonRpcProtocolFilter> jsonrpc_filter_;
 };
+
+}  // namespace
 
 bool StdioFilterChainFactory::createFilterChain(
     network::FilterManager& filter_manager) const {

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -789,6 +789,21 @@ SessionManager::SessionPtr McpServer::getOrCreateSessionFor(
         transport_session_id);
   }
 
+  // No origin at all: a context-free legacy dispatch. A null-keyed
+  // session can never be found again by getSessionByConnection, so
+  // creating one per message would leak an unretrievable session per
+  // message until max_sessions starves every transport. Keep exactly one
+  // shared session for this path instead — which also preserves a legacy
+  // client's initialize/subscription state across messages. Re-create it
+  // only if the expiry sweep removed it.
+  if (context.originConnection() == nullptr) {
+    if (!legacy_session_ ||
+        !session_manager_->getSession(legacy_session_->getId())) {
+      legacy_session_ = session_manager_->createSession(nullptr);
+    }
+    return legacy_session_;
+  }
+
   // Connection-keyed fallback for transports where the connection is
   // long-lived (stdio) or there is no transport session concept. The
   // origin comes from the message itself, so interleaved reads from
@@ -839,11 +854,19 @@ void McpServer::onRequest(const jsonrpc::Request& request) {
   // came from. Every in-tree transport dispatches through
   // onRequestWithContext; reaching this path means an external producer
   // has not been migrated, so route replies through the degraded legacy
-  // fallback rather than guessing at a connection.
-  GOPHER_LOG_WARN(
-      "Request '{}' dispatched without origin context; session and reply "
-      "routing degraded to the legacy transport fallback",
-      request.method);
+  // fallback rather than guessing at a connection. Warn once per server —
+  // a legacy producer hits this on every message, and repeating the same
+  // warning per message is flooding, not signal.
+  if (!legacy_dispatch_warned_) {
+    legacy_dispatch_warned_ = true;
+    GOPHER_LOG_WARN(
+        "Request '{}' dispatched without origin context; session and reply "
+        "routing degraded to the legacy transport fallback (warned once; "
+        "further context-free dispatches log at debug)",
+        request.method);
+  } else {
+    GOPHER_LOG_DEBUG("Context-free dispatch of request '{}'", request.method);
+  }
   LegacyDispatchContext context(*this);
   onRequestWithContext(request, context);
 }
@@ -978,11 +1001,19 @@ void McpServer::onRequestWithContext(const jsonrpc::Request& request,
 }
 
 void McpServer::onNotification(const jsonrpc::Notification& notification) {
-  // Context-free legacy entry; see onRequest for why this is degraded.
-  GOPHER_LOG_WARN(
-      "Notification '{}' dispatched without origin context; session "
-      "resolution degraded to the legacy transport fallback",
-      notification.method);
+  // Context-free legacy entry; see onRequest for why this is degraded and
+  // why the warning fires only once per server.
+  if (!legacy_dispatch_warned_) {
+    legacy_dispatch_warned_ = true;
+    GOPHER_LOG_WARN(
+        "Notification '{}' dispatched without origin context; session "
+        "resolution degraded to the legacy transport fallback (warned once; "
+        "further context-free dispatches log at debug)",
+        notification.method);
+  } else {
+    GOPHER_LOG_DEBUG("Context-free dispatch of notification '{}'",
+                     notification.method);
+  }
   LegacyDispatchContext context(*this);
   onNotificationWithContext(notification, context);
 }

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -133,7 +133,9 @@ void McpServer::performListen() {
       conn_config.transport_type = TransportType::Stdio;
       conn_config.buffer_limit = config_.buffer_high_watermark;
       conn_config.connection_timeout = config_.request_processing_timeout;
-      conn_config.stdio_config = transport::StdioTransportSocketConfig();
+      conn_config.stdio_config = config_.stdio_transport_config.has_value()
+                                     ? config_.stdio_transport_config.value()
+                                     : transport::StdioTransportSocketConfig();
 
       auto conn_manager = std::make_unique<McpConnectionManager>(
           *main_dispatcher_, *socket_interface_, conn_config);
@@ -544,26 +546,36 @@ VoidResult McpServer::sendNotificationToSession(
               "SSE stream gone for session " + session->getId()));
   }
 
-  // Connection-keyed HTTP session: no valid server-initiated channel.
-  // HTTP/1.1 has no message outside a request/response cycle, so writing
-  // raw JSON to the connection would corrupt its framing. Such a session is
-  // also only ever an alias of an HTTP+SSE client whose real push channel
-  // is the SSE stream (the transport-keyed session above) — writing here
-  // too would duplicate the delivery. And on the posted off-thread path the
-  // connection may already be freed. So we deliberately do NOT write to
-  // session->getConnection(); we fail cleanly. (getConnection() is only
-  // compared to null here, never dereferenced, which is safe even if the
-  // pointer dangles.)
+  // Connection-keyed session. Since the dispatch context supplies the
+  // origin connection for every transport, stdio sessions are keyed on
+  // the pipe connection too — and stdio DOES have a push channel: the
+  // long-lived pipe, written through the connection manager that frames
+  // for it. Route through the manager that owns the session's connection.
+  // (ownsConnection only compares pointers, never dereferences, which is
+  // safe even if the pointer dangles on the posted off-thread path.)
   if (session->getConnection()) {
+    for (auto& conn_manager : connection_managers_) {
+      if (conn_manager->isConnected() &&
+          conn_manager->ownsConnection(session->getConnection())) {
+        return conn_manager->sendNotification(notification);
+      }
+    }
+
+    // No manager owns it: a plain-HTTP connection. HTTP/1.1 has no message
+    // outside a request/response cycle, so writing raw JSON to the
+    // connection would corrupt its framing. Such a session is also only
+    // ever an alias of an HTTP+SSE client whose real push channel is the
+    // SSE stream (the transport-keyed session above) — writing here too
+    // would duplicate the delivery. Fail cleanly instead.
     return makeVoidError(
         Error(jsonrpc::INTERNAL_ERROR,
               "Session " + session->getId() +
                   " has no server-initiated notification channel"));
   }
 
-  // Neither key: stdio. Requests are dispatched without a connection
-  // pointer, so the session carries no key. There is a single stdio client,
-  // reached through its connection manager.
+  // No key at all: only reachable for sessions created by the context-free
+  // legacy dispatch path. There is a single stdio client, reached through
+  // its connection manager.
   for (auto& conn_manager : connection_managers_) {
     if (conn_manager->isConnected()) {
       return conn_manager->sendNotification(notification);

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -817,20 +817,15 @@ SessionManager::SessionPtr McpServer::getOrCreateSessionFor(
 }
 
 // Reply path for messages that arrived through the context-free legacy
-// hooks. There is no origin connection to reply on, so fall back to the
-// first connected stdio manager — the historical degraded behavior — and
-// fail loudly when there is none, instead of writing to an unrelated
-// connection.
-class McpServer::LegacyDispatchContext : public MessageDispatchContext {
+// hooks. The "no origin" half of the contract (null connection, empty
+// transport session id) is inherited from NullMessageDispatchContext so
+// it is defined in exactly one place; only the reply path differs: fall
+// back to the first connected stdio manager — the historical degraded
+// behavior — and fail loudly when there is none, instead of writing to
+// an unrelated connection.
+class McpServer::LegacyDispatchContext : public NullMessageDispatchContext {
  public:
   explicit LegacyDispatchContext(McpServer& server) : server_(server) {}
-
-  network::Connection* originConnection() const override { return nullptr; }
-
-  const std::string& transportSessionId() const override {
-    static const std::string empty;
-    return empty;
-  }
 
   VoidResult sendResponse(const jsonrpc::Response& response) override {
     for (auto& conn_manager : server_.connection_managers_) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1668,6 +1668,17 @@ target_link_libraries(test_server_notification_delivery
 )
 add_test(NAME ServerNotificationDeliveryTest COMMAND test_server_notification_delivery)
 
+add_executable(test_stdio_server_push integration/test_stdio_server_push.cc)
+target_link_libraries(test_stdio_server_push
+    gopher-mcp
+    gopher-mcp-event
+    gtest
+    gtest_main
+    gmock
+    Threads::Threads
+)
+add_test(NAME StdioServerPushTest COMMAND test_stdio_server_push)
+
 add_executable(test_mcp_server_request_routing integration/test_mcp_server_request_routing.cc)
 target_link_libraries(test_mcp_server_request_routing
     gopher-mcp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(test_mcp_server_responses server/test_mcp_server_responses.cc)
 add_executable(test_resource_read server/test_resource_read.cc)
 add_executable(test_session_manager_capacity server/test_session_manager_capacity.cc)
 add_executable(test_session_transport_binding server/test_session_transport_binding.cc)
+add_executable(test_legacy_dispatch_session server/test_legacy_dispatch_session.cc)
 # CORS tests
 add_executable(test_cors_headers filter/test_cors_headers.cc)
 add_executable(test_options_notification filter/test_options_notification.cc)
@@ -275,6 +276,15 @@ target_link_libraries(test_session_manager_capacity
 
 target_link_libraries(test_session_transport_binding
     gopher-mcp
+    gtest
+    gtest_main
+    Threads::Threads
+    fmt::fmt
+)
+
+target_link_libraries(test_legacy_dispatch_session
+    gopher-mcp
+    gopher-mcp-logging
     gtest
     gtest_main
     Threads::Threads
@@ -1348,6 +1358,7 @@ add_test(NAME McpServerResponsesTest COMMAND test_mcp_server_responses)
 add_test(NAME ResourceReadTest COMMAND test_resource_read)
 add_test(NAME SessionManagerCapacityTest COMMAND test_session_manager_capacity)
 add_test(NAME SessionTransportBindingTest COMMAND test_session_transport_binding)
+add_test(NAME LegacyDispatchSessionTest COMMAND test_legacy_dispatch_session)
 add_test(NAME CorsHeadersTest COMMAND test_cors_headers)
 add_test(NAME OptionsNotificationTest COMMAND test_options_notification)
 add_test(NAME EventLoopTest COMMAND test_event_loop)

--- a/tests/filter/CMakeLists.txt
+++ b/tests/filter/CMakeLists.txt
@@ -413,3 +413,18 @@ target_link_libraries(test_http_sse_factory_constructor
   Threads::Threads
 )
 add_test(NAME HttpSseFactoryConstructorTest COMMAND test_http_sse_factory_constructor)
+
+add_executable(test_message_handler_context_forwarding
+  test_message_handler_context_forwarding.cc
+)
+target_link_libraries(test_message_handler_context_forwarding
+  PRIVATE
+  gopher-mcp
+  gopher-mcp-logging
+  gtest
+  gtest_main
+  gmock
+  Threads::Threads
+  fmt::fmt
+)
+add_test(NAME MessageHandlerContextForwardingTest COMMAND test_message_handler_context_forwarding)

--- a/tests/filter/test_json_rpc_protocol_filter.cc
+++ b/tests/filter/test_json_rpc_protocol_filter.cc
@@ -14,6 +14,7 @@
 #include "mcp/buffer.h"
 #include "mcp/filter/json_rpc_protocol_filter.h"
 #include "mcp/json/json_serialization.h"
+#include "mcp/mcp_connection_manager.h"
 #include "mcp/network/connection_impl.h"
 #include "mcp/network/socket_impl.h"
 
@@ -381,6 +382,64 @@ TEST_F(JsonRpcProtocolFilterTest, RequestDispatchCarriesContext) {
   EXPECT_TRUE(handler->last_send_failed_)
       << "sendResponse with no connection must surface an error, not "
          "silently drop the reply";
+
+  executeInDispatcher([&]() { filter.reset(); });
+}
+
+/**
+ * The config-driven constructor installs ProtocolCallbackBridge between
+ * the filter and the McpProtocolCallbacks. That bridge must forward the
+ * per-message context: if it drops to the context-free hooks, every
+ * config-driven listener chain degrades to the application layer's
+ * legacy path and replies are never written on listener-only servers.
+ */
+TEST_F(JsonRpcProtocolFilterTest, ConfigDrivenBridgeForwardsContext) {
+  class CapturingProtocolCallbacks : public McpProtocolCallbacks {
+   public:
+    void onRequest(const jsonrpc::Request&) override { legacy_requests_++; }
+    void onNotification(const jsonrpc::Notification&) override {
+      legacy_notifications_++;
+    }
+    void onResponse(const jsonrpc::Response&) override {}
+    void onConnectionEvent(network::ConnectionEvent) override {}
+    void onError(const Error&) override {}
+
+    void onRequestWithContext(const jsonrpc::Request&,
+                              MessageDispatchContext&) override {
+      context_requests_++;
+    }
+    void onNotificationWithContext(const jsonrpc::Notification&,
+                                   MessageDispatchContext&) override {
+      context_notifications_++;
+    }
+
+    int legacy_requests_{0};
+    int legacy_notifications_{0};
+    int context_requests_{0};
+    int context_notifications_{0};
+  };
+
+  auto callbacks = std::make_unique<CapturingProtocolCallbacks>();
+  std::unique_ptr<JsonRpcProtocolFilter> filter;
+  executeInDispatcher([&]() {
+    FilterCreationContext context(*dispatcher_, *callbacks,
+                                  ConnectionMode::Server, TransportMetadata());
+    filter = std::make_unique<JsonRpcProtocolFilter>(context,
+                                                     json::JsonValue::object());
+    OwnedBuffer buffer;
+    buffer.add(
+        std::string(R"({"jsonrpc":"2.0","id":9,"method":"test.method"})") +
+        "\n" + std::string(R"({"jsonrpc":"2.0","method":"note.method"})") +
+        "\n");
+    filter->onData(buffer, false);
+  });
+
+  EXPECT_EQ(callbacks->context_requests_, 1)
+      << "bridge must forward the request context, not strip it";
+  EXPECT_EQ(callbacks->legacy_requests_, 0);
+  EXPECT_EQ(callbacks->context_notifications_, 1)
+      << "bridge must forward the notification context, not strip it";
+  EXPECT_EQ(callbacks->legacy_notifications_, 0);
 
   executeInDispatcher([&]() { filter.reset(); });
 }

--- a/tests/filter/test_json_rpc_protocol_filter.cc
+++ b/tests/filter/test_json_rpc_protocol_filter.cc
@@ -387,6 +387,93 @@ TEST_F(JsonRpcProtocolFilterTest, RequestDispatchCarriesContext) {
 }
 
 /**
+ * sendResponse must fail — not silently succeed — when the origin
+ * connection is no longer open. write_callbacks_ is set once at chain
+ * init and never cleared, and ConnectionImpl::write on a non-open
+ * connection silently discards, so the sink's state check is the only
+ * thing standing between "client hung up mid-dispatch" and a response
+ * that reports sent while nothing went out.
+ *
+ * Real IO: the filter is wired to a real server connection over a
+ * socketpair; the handler closes the connection during dispatch (the
+ * client-hung-up shape) and then tries to reply.
+ */
+TEST_F(JsonRpcProtocolFilterTest, SendResponseFailsOnClosedConnection) {
+  class ClosingHandler : public JsonRpcProtocolFilter::MessageHandler {
+   public:
+    void onRequest(const jsonrpc::Request&) override {}
+    void onNotification(const jsonrpc::Notification&) override {}
+    void onResponse(const jsonrpc::Response&) override {}
+    void onProtocolError(const Error&) override {}
+
+    void onRequestWithContext(const jsonrpc::Request& request,
+                              MessageDispatchContext& context) override {
+      // Reply while open: must succeed.
+      open_send_ok_ = !holds_alternative<Error>(
+          context.sendResponse(jsonrpc::Response::make_error(
+              request.id, Error(jsonrpc::INTERNAL_ERROR, "while open"))));
+
+      // Client hangs up mid-dispatch (local close has the same state
+      // effect); the second reply must surface an error.
+      connection_->close(network::ConnectionCloseType::NoFlush);
+      closed_send_failed_ = holds_alternative<Error>(
+          context.sendResponse(jsonrpc::Response::make_error(
+              request.id, Error(jsonrpc::INTERNAL_ERROR, "after close"))));
+    }
+
+    network::Connection* connection_{nullptr};
+    bool open_send_ok_{false};
+    bool closed_send_failed_{false};
+  };
+
+  auto handler = std::make_unique<ClosingHandler>();
+  network::ConnectionPtr conn;
+  network::IoHandlePtr peer;
+  std::shared_ptr<JsonRpcProtocolFilter> wired_filter;
+
+  executeInDispatcher([&]() {
+    auto pair = createSocketPair();
+    auto local = network::Address::parseInternetAddress("127.0.0.1", 0);
+    auto remote = network::Address::parseInternetAddress("127.0.0.1", 0);
+    auto socket = std::make_unique<network::ConnectionSocketImpl>(
+        std::move(pair.first), local, remote);
+    auto transport = std::make_unique<network::RawBufferTransportSocket>();
+    auto si = std::make_shared<stream_info::StreamInfoImpl>();
+
+    conn = network::ConnectionImpl::createServerConnection(
+        *dispatcher_, std::move(socket), std::move(transport), *si);
+    peer = std::move(pair.second);
+    handler->connection_ = conn.get();
+
+    wired_filter = std::make_shared<JsonRpcProtocolFilter>(
+        *handler, *dispatcher_, /*is_server=*/true);
+    auto* ci = dynamic_cast<network::ConnectionImpl*>(conn.get());
+    ASSERT_NE(ci, nullptr);
+    ci->filterManager().addReadFilter(wired_filter);
+    ci->filterManager().addWriteFilter(wired_filter);
+    ci->filterManager().initializeReadFilters();
+
+    // Dispatch a request through the wired filter.
+    OwnedBuffer buffer;
+    buffer.add(
+        std::string(R"({"jsonrpc":"2.0","id":11,"method":"test.method"})") +
+        "\n");
+    wired_filter->onData(buffer, false);
+  });
+
+  EXPECT_TRUE(handler->open_send_ok_)
+      << "reply on an open connection must succeed";
+  EXPECT_TRUE(handler->closed_send_failed_)
+      << "reply after the connection closed must return an error, not "
+         "silently report success";
+
+  executeInDispatcher([&]() {
+    wired_filter.reset();
+    conn.reset();
+  });
+}
+
+/**
  * The config-driven constructor installs ProtocolCallbackBridge between
  * the filter and the McpProtocolCallbacks. That bridge must forward the
  * per-message context: if it drops to the context-free hooks, every

--- a/tests/filter/test_message_handler_context_forwarding.cc
+++ b/tests/filter/test_message_handler_context_forwarding.cc
@@ -1,0 +1,206 @@
+/**
+ * Unit tests: chainable MessageHandler filters must forward the
+ * per-message dispatch context.
+ *
+ * Every filter that can be spliced between a JsonRpcProtocolFilter and the
+ * application bridge via setNextCallbacks (metrics, circuit breaker,
+ * request validation, request logging) has to override the
+ * context-carrying hooks and pass the SAME context object through.
+ * A filter that forwards only via the context-free hooks silently strips
+ * the message's origin: the application layer then keys sessions on a
+ * null connection and replies through its degraded legacy path — dropped
+ * or misrouted responses with only a WARN log as evidence. These tests
+ * pin identity-preserving forwarding for each filter.
+ */
+
+#include <gtest/gtest.h>
+
+#include "mcp/filter/circuit_breaker_filter.h"
+#include "mcp/filter/json_rpc_protocol_filter.h"
+#include "mcp/filter/metrics_filter.h"
+#include "mcp/filter/request_logger_filter.h"
+#include "mcp/filter/request_validation_filter.h"
+#include "mcp/message_dispatch_context.h"
+
+namespace mcp {
+namespace filter {
+namespace {
+
+/** Terminal handler recording which hook fired and which context arrived. */
+class CapturingNextHandler : public JsonRpcProtocolFilter::MessageHandler {
+ public:
+  void onRequest(const jsonrpc::Request&) override { legacy_requests_++; }
+  void onNotification(const jsonrpc::Notification&) override {
+    legacy_notifications_++;
+  }
+  void onResponse(const jsonrpc::Response&) override {}
+  void onProtocolError(const Error&) override {}
+
+  void onRequestWithContext(const jsonrpc::Request&,
+                            MessageDispatchContext& context) override {
+    context_requests_++;
+    last_context_ = &context;
+  }
+
+  void onNotificationWithContext(const jsonrpc::Notification&,
+                                 MessageDispatchContext& context) override {
+    context_notifications_++;
+    last_context_ = &context;
+  }
+
+  int legacy_requests_{0};
+  int legacy_notifications_{0};
+  int context_requests_{0};
+  int context_notifications_{0};
+  MessageDispatchContext* last_context_{nullptr};
+};
+
+/** Context that records replies sent through it. */
+class RecordingContext : public MessageDispatchContext {
+ public:
+  network::Connection* originConnection() const override { return nullptr; }
+  const std::string& transportSessionId() const override { return id_; }
+  VoidResult sendResponse(const jsonrpc::Response& response) override {
+    sent_responses_.push_back(response);
+    return makeVoidSuccess();
+  }
+
+  std::string id_{"test-stream-7"};
+  std::vector<jsonrpc::Response> sent_responses_;
+};
+
+jsonrpc::Request makePing() {
+  jsonrpc::Request request;
+  request.jsonrpc = "2.0";
+  request.id = make_request_id(int64_t{1});
+  request.method = "ping";
+  return request;
+}
+
+jsonrpc::Notification makeNotification() {
+  jsonrpc::Notification notification;
+  notification.jsonrpc = "2.0";
+  // "ping" is in the validation filter's default allowed-methods list, so
+  // the same message passes every filter under test.
+  notification.method = "ping";
+  return notification;
+}
+
+// The assertion shared by every filter: the WithContext hook fires on the
+// next handler (not the context-free one), and the context arrives by
+// identity — the exact object the producer built, no copy, no substitute.
+template <typename Filter>
+void expectContextForwarded(Filter& filter, CapturingNextHandler& next) {
+  RecordingContext context;
+
+  filter.onRequestWithContext(makePing(), context);
+  EXPECT_EQ(next.context_requests_, 1);
+  EXPECT_EQ(next.legacy_requests_, 0)
+      << "context-free hook must not run when a context was supplied";
+  EXPECT_EQ(next.last_context_, &context)
+      << "context must be forwarded by identity, not replaced";
+
+  filter.onNotificationWithContext(makeNotification(), context);
+  EXPECT_EQ(next.context_notifications_, 1);
+  EXPECT_EQ(next.legacy_notifications_, 0);
+  EXPECT_EQ(next.last_context_, &context);
+}
+
+TEST(MessageHandlerContextForwarding, MetricsFilterForwardsContext) {
+  class NullMetricsCallbacks : public MetricsFilter::MetricsCallbacks {
+   public:
+    void onMetricsUpdate(const ConnectionMetrics&) override {}
+    void onThresholdExceeded(const std::string&, uint64_t, uint64_t) override {}
+  };
+
+  NullMetricsCallbacks callbacks;
+  MetricsFilter filter(callbacks, MetricsFilter::Config());
+  CapturingNextHandler next;
+  filter.setNextCallbacks(&next);
+
+  expectContextForwarded(filter, next);
+
+  // The context path must record metrics identically to the legacy path.
+  ConnectionMetrics snapshot;
+  filter.getMetrics(snapshot);
+  EXPECT_EQ(snapshot.requests_received.load(), 1u);
+  EXPECT_EQ(snapshot.notifications_received.load(), 1u);
+}
+
+TEST(MessageHandlerContextForwarding, CircuitBreakerFilterForwardsContext) {
+  CircuitBreakerFilter filter(nullptr, CircuitBreakerConfig());
+  CapturingNextHandler next;
+  filter.setNextCallbacks(&next);
+
+  expectContextForwarded(filter, next);
+}
+
+TEST(MessageHandlerContextForwarding,
+     CircuitBreakerRepliesThroughContextWhenOpen) {
+  // Trip the breaker, then verify a blocked request is answered through
+  // the message's own reply path instead of silently timing out — the
+  // behavior the context finally makes possible.
+  CircuitBreakerConfig config;
+  config.failure_threshold = 1;
+  CircuitBreakerFilter filter(nullptr, config);
+  CapturingNextHandler next;
+  filter.setNextCallbacks(&next);
+
+  RecordingContext context;
+
+  // One failing request/response cycle opens the circuit.
+  filter.onRequestWithContext(makePing(), context);
+  jsonrpc::Response failure;
+  failure.jsonrpc = "2.0";
+  failure.id = make_request_id(int64_t{1});
+  failure.error =
+      mcp::make_optional(Error(jsonrpc::INTERNAL_ERROR, "backend down"));
+  filter.onResponse(failure);
+
+  // Blocked request: not forwarded, answered via the context.
+  jsonrpc::Request blocked;
+  blocked.jsonrpc = "2.0";
+  blocked.id = make_request_id(int64_t{2});
+  blocked.method = "ping";
+  filter.onRequestWithContext(blocked, context);
+
+  EXPECT_EQ(next.context_requests_, 1)
+      << "blocked request must not be forwarded";
+  ASSERT_EQ(context.sent_responses_.size(), 1u)
+      << "blocked request must be answered through the dispatch context";
+  ASSERT_TRUE(context.sent_responses_[0].error.has_value());
+  EXPECT_EQ(context.sent_responses_[0].error->message,
+            "Circuit breaker is open");
+}
+
+TEST(MessageHandlerContextForwarding, RequestValidationFilterForwardsContext) {
+  class NullValidationCallbacks
+      : public RequestValidationFilter::ValidationCallbacks {
+   public:
+    void onRequestValidated(const std::string&) override {}
+    void onRequestRejected(const std::string&, const std::string&) override {}
+    void onRateLimitExceeded(const std::string&) override {}
+  };
+
+  NullValidationCallbacks callbacks;
+  // Default config allows "ping"/"initialized"-style MCP methods.
+  RequestValidationFilter filter(callbacks, RequestValidationConfig());
+  CapturingNextHandler next;
+  filter.setNextCallbacks(&next);
+
+  expectContextForwarded(filter, next);
+}
+
+TEST(MessageHandlerContextForwarding, RequestLoggerFilterForwardsContext) {
+  RequestLoggerFilter::Config config;
+  config.include_payload = false;
+  RequestLoggerFilter filter(config);
+  CapturingNextHandler next;
+  filter.setNextCallbacks(&next);
+
+  expectContextForwarded(filter, next);
+}
+
+}  // namespace
+}  // namespace filter
+}  // namespace mcp

--- a/tests/integration/test_http_sse_filter_server_mode.cc
+++ b/tests/integration/test_http_sse_filter_server_mode.cc
@@ -342,6 +342,83 @@ TEST_F(ServerModeFilterTest, PlainPost_AnnouncesEmptyBinding) {
   closeOnDispatcher(std::move(conn), std::move(factory));
 }
 
+// ── Callback-proxy notification must not leak a 202 onto the SSE stream ──
+//
+// A notification POSTed to /callback/{id} is already answered with a 202
+// at header time. The dispatch-time 202 the plain-HTTP path needs would be
+// captured by onWrite's callback-proxy branch and shipped down the
+// client's SSE stream as event data ("data: HTTP/1.1 202 Accepted..."),
+// corrupting the stream. This test opens a real SSE stream, POSTs a
+// notification to its callback URL from a second connection, and requires
+// the SSE stream to stay free of HTTP status lines.
+TEST_F(ServerModeFilterTest, CallbackNotification_No202OnSseStream) {
+  ServerModeCallbacks callbacks;
+  std::unique_ptr<network::ServerConnection> sse_conn;
+  network::IoHandlePtr sse_peer;
+  std::shared_ptr<HttpSseFilterChainFactory> factory;
+
+  // Connection 1: open the SSE stream and learn the callback URL.
+  executeInDispatcher([&]() {
+    auto h = makeServerHarness(callbacks);
+    sse_conn = std::move(h.conn);
+    sse_peer = std::move(h.peer);
+    factory = std::move(h.factory);
+
+    writeClientBytes(*sse_peer,
+                     "GET /sse HTTP/1.1\r\n"
+                     "Host: localhost\r\n"
+                     "Accept: text/event-stream\r\n"
+                     "\r\n");
+  });
+
+  std::string handshake = drainPeer(*sse_peer, 500ms);
+  auto cb_pos = handshake.find("callback/");
+  ASSERT_NE(cb_pos, std::string::npos)
+      << "endpoint event with callback URL expected, got: " << handshake;
+  auto id_start = cb_pos + std::string("callback/").size();
+  auto id_end = handshake.find_first_of("\r\n \"", id_start);
+  const std::string session_id = handshake.substr(id_start, id_end - id_start);
+  ASSERT_FALSE(session_id.empty());
+
+  // Connection 2 (same factory, shared registry): POST a notification to
+  // the callback URL.
+  std::unique_ptr<network::ServerConnection> post_conn;
+  network::IoHandlePtr post_peer;
+  executeInDispatcher([&]() {
+    auto h = makeServerHarness(callbacks, factory);
+    post_conn = std::move(h.conn);
+    post_peer = std::move(h.peer);
+
+    std::string body = R"({"jsonrpc":"2.0","method":"initialized"})";
+    writeClientBytes(*post_peer, "POST /callback/" + session_id +
+                                     " HTTP/1.1\r\n"
+                                     "Host: localhost\r\n"
+                                     "Content-Type: application/json\r\n"
+                                     "Content-Length: " +
+                                     std::to_string(body.size()) + "\r\n\r\n" +
+                                     body);
+  });
+
+  std::this_thread::sleep_for(200ms);
+
+  // The POST connection gets exactly the header-time 202.
+  std::string on_post = drainPeer(*post_peer, 300ms);
+  EXPECT_NE(on_post.find("202"), std::string::npos)
+      << "callback POST must be acknowledged, got: " << on_post;
+  EXPECT_EQ(on_post.find("202", on_post.find("202") + 1), std::string::npos)
+      << "callback POST must be acknowledged exactly once, got: " << on_post;
+
+  // The SSE stream must carry no HTTP status line as event data.
+  std::string on_sse = drainPeer(*sse_peer, 300ms);
+  EXPECT_EQ(on_sse.find("202 Accepted"), std::string::npos)
+      << "raw HTTP 202 leaked onto the SSE stream as event data: " << on_sse;
+
+  ASSERT_EQ(callbacks.requests_.size(), 0u);
+
+  closeOnDispatcher(std::move(post_conn), nullptr);
+  closeOnDispatcher(std::move(sse_conn), std::move(factory));
+}
+
 // ── SseStream body ignored ────────────────────────────────────────
 
 TEST_F(ServerModeFilterTest, SseStream_BodyIgnored) {

--- a/tests/integration/test_stdio_server_push.cc
+++ b/tests/integration/test_stdio_server_push.cc
@@ -1,0 +1,161 @@
+/**
+ * Integration test: stdio server-push reaches the client.
+ *
+ * Since the per-message dispatch context supplies the origin connection
+ * for every transport, stdio sessions are keyed on the pipe connection.
+ * sendNotificationToSession must therefore route a connection-keyed
+ * session through the connection manager that OWNS that connection —
+ * treating every connection-keyed session as "plain HTTP, no push
+ * channel" silently regresses stdio server push (the issue #240
+ * scenario: notifications/resources/updated never reaches a stdio
+ * subscriber, and the only evidence is a per-call error return the
+ * caller usually ignores).
+ *
+ * The test drives a real McpServer over real pipes: the server's stdio
+ * transport is pointed at pipe fds (use_bridge=false, the test-pipe
+ * mode), a subscribe request goes in on the "stdin" pipe, and the
+ * resource-update notification must come back on the "stdout" pipe.
+ */
+
+#include <chrono>
+#include <cstdint>
+#include <fcntl.h>
+#include <string>
+#include <thread>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include "mcp/server/mcp_server.h"
+#include "mcp/types.h"
+
+namespace mcp {
+namespace {
+
+using namespace std::chrono_literals;
+
+// The server-side stdio chain uses length-prefixed framing (4-byte
+// big-endian), the same framing McpConnectionManager defaults to.
+std::string frame(const std::string& json) {
+  std::string framed;
+  uint32_t len = static_cast<uint32_t>(json.size());
+  framed.push_back(static_cast<char>((len >> 24) & 0xff));
+  framed.push_back(static_cast<char>((len >> 16) & 0xff));
+  framed.push_back(static_cast<char>((len >> 8) & 0xff));
+  framed.push_back(static_cast<char>(len & 0xff));
+  framed += json;
+  return framed;
+}
+
+class StdioServerPushTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // client_to_server: test writes requests, server reads them as stdin.
+    // server_to_client: server writes replies/pushes, test reads them.
+    ASSERT_EQ(::pipe(client_to_server_), 0);
+    ASSERT_EQ(::pipe(server_to_client_), 0);
+
+    server::McpServerConfig config;
+    config.server_name = "stdio-push-test-server";
+    config.server_version = "0.0.1";
+    config.supported_transports = {TransportType::Stdio};
+    config.num_workers = 1;
+
+    transport::StdioTransportSocketConfig stdio_config;
+    stdio_config.stdin_fd = client_to_server_[0];
+    stdio_config.stdout_fd = server_to_client_[1];
+    stdio_config.non_blocking = true;
+    stdio_config.use_bridge = false;  // test pipes, no bridge threads
+    config.stdio_transport_config = mcp::make_optional(stdio_config);
+
+    server_ = server::createMcpServer(config);
+    ASSERT_NE(server_, nullptr);
+
+    auto listen_result = server_->listen("stdio://");
+    ASSERT_TRUE(holds_alternative<std::nullptr_t>(listen_result))
+        << "McpServer::listen failed for stdio";
+
+    server_thread_ = std::thread([this]() { server_->run(); });
+
+    // Keep the test-side read end non-blocking so read polls can time out.
+    ::fcntl(server_to_client_[0], F_SETFL, O_NONBLOCK);
+  }
+
+  void TearDown() override {
+    if (server_) {
+      server_->shutdown();
+    }
+    if (server_thread_.joinable()) {
+      server_thread_.join();
+    }
+    server_.reset();
+    // The transport closed the fds it owned; close the test-side ends.
+    ::close(client_to_server_[1]);
+    ::close(server_to_client_[0]);
+  }
+
+  bool writeToServer(const std::string& bytes) {
+    return ::write(client_to_server_[1], bytes.data(), bytes.size()) ==
+           static_cast<ssize_t>(bytes.size());
+  }
+
+  // Accumulate framed bytes from the server until the payload of some
+  // frame contains `needle` or the budget elapses. Returns everything
+  // read (frames included) for diagnostics.
+  std::string readUntilContains(const std::string& needle,
+                                std::chrono::milliseconds budget) {
+    std::string received;
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    char buf[4096];
+    while (std::chrono::steady_clock::now() < deadline) {
+      ssize_t n = ::read(server_to_client_[0], buf, sizeof(buf));
+      if (n > 0) {
+        received.append(buf, static_cast<size_t>(n));
+        if (received.find(needle) != std::string::npos) {
+          return received;
+        }
+      } else if (n == 0) {
+        return received;  // EOF
+      }
+      std::this_thread::sleep_for(10ms);
+    }
+    return received;
+  }
+
+  int client_to_server_[2]{-1, -1};
+  int server_to_client_[2]{-1, -1};
+  std::unique_ptr<server::McpServer> server_;
+  std::thread server_thread_;
+};
+
+// Subscribe over stdio, then push a resource update: the notification
+// must arrive on the stdio client's pipe. With connection-keyed stdio
+// sessions misclassified as "no push channel", the subscribe response
+// still arrives but the notification never does.
+TEST_F(StdioServerPushTest, ResourceUpdateReachesStdioSubscriber) {
+  const std::string kUri = "test://resource/stdio-watched";
+
+  ASSERT_TRUE(writeToServer(frame(
+      R"({"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":")" +
+      kUri + R"("}})")));
+
+  std::string subscribe_reply = readUntilContains("\"id\":1", 5s);
+  ASSERT_NE(subscribe_reply.find("\"id\":1"), std::string::npos)
+      << "resources/subscribe was never answered on the stdio pipe; got: "
+      << subscribe_reply;
+
+  // The subscription is recorded under the session keyed on the stdio
+  // connection. The push must route back through the stdio manager.
+  server_->notifyResourceUpdate(kUri);
+
+  std::string pushed = readUntilContains("notifications/resources/updated", 5s);
+  EXPECT_NE(pushed.find("notifications/resources/updated"), std::string::npos)
+      << "resource-update notification never reached the stdio client; "
+         "connection-keyed stdio session was likely classified as having "
+         "no push channel. Received instead: "
+      << pushed;
+  EXPECT_NE(pushed.find(kUri), std::string::npos);
+}
+
+}  // namespace
+}  // namespace mcp

--- a/tests/server/test_legacy_dispatch_session.cc
+++ b/tests/server/test_legacy_dispatch_session.cc
@@ -1,0 +1,92 @@
+/**
+ * Unit tests: the context-free legacy dispatch path must not leak
+ * sessions.
+ *
+ * A message arriving through the context-free hooks carries no origin
+ * connection, so the session lookup has no key. Creating a session per
+ * message would register one unretrievable (null-keyed) session per
+ * message until max_sessions is exhausted — at which point EVERY
+ * transport on the server starts failing with "Max sessions reached".
+ * The server instead keeps exactly one shared session for the
+ * context-free path, which also preserves a legacy client's state
+ * across its messages.
+ */
+
+#include <gtest/gtest.h>
+
+#include "mcp/server/mcp_server.h"
+#include "mcp/types.h"
+
+namespace mcp {
+namespace server {
+namespace {
+
+// Widen access to the protected context-free hooks — the test drives the
+// exact entry an un-migrated external producer would use.
+class LegacyDispatchTestServer : public McpServer {
+ public:
+  explicit LegacyDispatchTestServer(const McpServerConfig& config)
+      : McpServer(config) {}
+  using McpServer::onNotification;
+  using McpServer::onRequest;
+};
+
+jsonrpc::Request makePing(int64_t id) {
+  jsonrpc::Request request;
+  request.jsonrpc = "2.0";
+  request.id = make_request_id(id);
+  request.method = "ping";
+  return request;
+}
+
+TEST(LegacyDispatchSession, ContextFreeMessagesShareOneSession) {
+  McpServerConfig config;
+  config.server_name = "legacy-dispatch-test";
+  config.server_version = "0.0.1";
+  LegacyDispatchTestServer server(config);
+
+  const auto& stats = server.getServerStats();
+  ASSERT_EQ(stats.sessions_total.load(), 0u);
+
+  // Ten context-free requests and notifications: exactly ONE session may
+  // be created, and it must be reused for every subsequent message.
+  for (int64_t i = 1; i <= 5; ++i) {
+    server.onRequest(makePing(i));
+
+    jsonrpc::Notification notification;
+    notification.jsonrpc = "2.0";
+    notification.method = "ping";
+    server.onNotification(notification);
+  }
+
+  EXPECT_EQ(stats.sessions_total.load(), 1u)
+      << "context-free dispatches must share one session, not leak one "
+         "per message";
+  EXPECT_EQ(stats.sessions_active.load(), 1u);
+}
+
+TEST(LegacyDispatchSession, ContextFreeSessionDoesNotStarveMaxSessions) {
+  McpServerConfig config;
+  config.server_name = "legacy-dispatch-capacity-test";
+  config.server_version = "0.0.1";
+  config.max_sessions = 3;
+  LegacyDispatchTestServer server(config);
+
+  // Far more context-free messages than max_sessions: with the leak,
+  // request #4 onward would fail with "Max sessions reached"; with the
+  // shared session the capacity is never approached.
+  for (int64_t i = 1; i <= 10; ++i) {
+    server.onRequest(makePing(i));
+  }
+
+  const auto& stats = server.getServerStats();
+  EXPECT_EQ(stats.sessions_total.load(), 1u);
+  EXPECT_LT(stats.sessions_active.load(),
+            static_cast<uint64_t>(config.max_sessions))
+      << "legacy dispatches must not consume the session capacity other "
+         "transports depend on";
+}
+
+}  // namespace
+}  // namespace server
+}  // namespace mcp


### PR DESCRIPTION
## Summary

Fixes every confirmed finding from the review of #264 (the dispatch-context refactor), one commit per finding:

1. **In-chain handlers no longer strip the context.** `ProtocolCallbackBridge` — the handler installed by the config-driven `json_rpc.dispatcher` chain — and the four chainable message filters (metrics, circuit breaker, request validation, request logging) forwarded only the context-free hooks. On a config-driven listener that sent every request to the degraded legacy path where a listener-only server has no reply route: responses were never written. All now forward the context-carrying hooks, with shared work factored into helpers so the entries cannot drift. The circuit breaker additionally uses the context's reply path to answer blocked requests with the circuit-open error instead of a silent timeout, and its admission lock no longer covers downstream dispatch.
2. **Stdio server push restored.** Stdio sessions are connection-keyed now that the context supplies an origin for every transport, which routed them into the "no push channel" error. Connection-keyed sessions owned by a connection manager deliver through that manager; `McpServerConfig` gains an optional stdio transport override so the regression test drives a real server over real pipes.
3. **ODR violation resolved.** The stdio factory's private duplicate of `DirectJsonRpcCallbacks` (same mangled name, diverging vtable layout after the context hooks) is deleted in favor of the public definition; the private wrapper filter moves into an anonymous namespace.
4. **Context-free dispatch bounded.** The legacy path used to leak one unretrievable null-keyed session per message until `max_sessions` starved every transport; it now keeps exactly one shared session, and the per-message WARN fires once per server.
5. **Reply sinks fail loud on closed origins.** Both context sinks now require the origin connection to be open; a client that hangs up mid-dispatch gets its failed reply logged and counted instead of reported as sent.
6. **Callback-proxy 202 leak fixed.** The dispatch-time 202 for notifications no longer fires in callback-proxy mode, where the header-time 202 already answered the POST and the unguarded write was captured by onWrite and shipped down the client's SSE stream as event data.
7. **Cleanups.** Dead `sendHttpResponse` helper removed; `LegacyDispatchContext` derives from `NullMessageDispatchContext` so the no-origin contract exists once.

## Testing

Full suite: 137/137 pass. New coverage: identity-preserving context forwarding for all four chainable filters and the config-driven bridge; circuit-open reply through the context; stdio subscribe→push round trip over real pipes (fails without the routing fix — verified); one shared session and no capacity starvation for context-free dispatches; sink error on a connection closed mid-dispatch; exactly one 202 on a callback POST with a clean SSE stream.