### PR TITLE
Add C++ MCP SDK comparison and adopters sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@
 - [Examples](#examples)
 - [Installation](#installation)
 - [Documentation](#documentation)
+- [Comparison with Other C++ MCP SDKs](#comparison-with-other-c-mcp-sdks)
 - [FAQ](#faq)
+- [Adopters](#adopters)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -299,6 +301,30 @@ Install [Cygwin](https://www.cygwin.com/) with these packages:
 - [CTAD Alternatives](docs/CTAD_alternatives.md) - Class Template Argument Deduction alternatives for C++14
 - [MCP Serialization Coverage](docs/MCP_serialization_coverage.md) - JSON serialization implementation details
 
+## Comparison with Other C++ MCP SDKs
+
+Several C++ implementations of the Model Context Protocol exist. They serve
+different needs — this table is meant to help you pick the right one:
+
+| | **gopher-mcp** (this SDK) | [hkr04/cpp-mcp](https://github.com/hkr04/cpp-mcp) | [Neumann-Labs/mcp-cpp](https://github.com/Neumann-Labs/mcp-cpp) |
+|---|---|---|---|
+| Focus | Production / enterprise deployments | Lightweight, minimal footprint | Modern C++20 framework |
+| MCP spec version | 2025-06-18 | 2025-03-26 | 2025-11-25 (in progress) |
+| C++ standard | C++14 / 17 / 20 | C++17 | C++20 |
+| Transports | stdio, HTTP+SSE, HTTPS, Streamable HTTP, WebSocket, TCP | stdio, HTTP+SSE | stdio, HTTP |
+| Client + server | Yes | Yes | Yes |
+| TLS | Yes | Yes (build flag) | — |
+| Event model | Event-driven dispatcher (libevent), thread-safe by design | — | — |
+| Resilience | Connection pooling, circuit breaker, rate limiting, backpressure | — | — |
+| Observability | Metrics, tracing hooks, structured logging | — | — |
+| Language bindings | Python, TypeScript, Go, Rust, Java, C#, Ruby via stable C API | C++ only | C++ only |
+| License | Apache-2.0 | MIT | MIT |
+
+If you need a small dependency for a quick stdio tool, a lightweight SDK like
+`cpp-mcp` is a fine choice. If you need an MCP C++ SDK for production —
+long-lived connections, multiple transports, observability, or calling the
+SDK from other languages — that is what gopher-mcp is built for.
+
 ## FAQ
 
 ### What is the Model Context Protocol?
@@ -329,9 +355,23 @@ Yes. The SDK includes connection pooling, circuit breakers, rate limiting, TLS s
 - **WebSocket** - Bidirectional real-time
 - **TCP** - Raw TCP sockets
 
+### How does this compare to cpp-mcp and other C++ MCP libraries?
+
+See the [comparison table](#comparison-with-other-c-mcp-sdks). In short:
+gopher-mcp targets production use — more transports (Streamable HTTP,
+WebSocket, TCP), connection pooling, circuit breakers, observability, and
+multi-language bindings — while lighter SDKs optimize for minimal footprint.
+
 ### How do I contribute?
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. Issues and pull requests welcome!
+
+## Adopters
+
+Using this MCP C++ SDK in your product or project? We'd love to list you
+here — open a pull request or issue to add yourself.
+
+- [Gopher Security](https://gopher.security) - MCP-native zero-trust security platform
 
 ## Keywords & Search Terms
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This MCP C++ SDK implements the [official MCP specification](https://modelcontex
 
 | Category | Features |
 |----------|----------|
-| **Protocol** | Full MCP 2025-06-18 specification, JSON-RPC 2.0, resources, tools, prompts |
+| **Protocol** | Full MCP 2025-06-18 and 2025-11-25 specifications, 2026-07-28 (in progress), JSON-RPC 2.0, resources, tools, prompts |
 | **Transports** | stdio, HTTP+SSE, HTTPS+SSE, WebSocket, TCP |
 | **Performance** | Zero-copy buffers, lock-free operations, connection pooling |
 | **Reliability** | Circuit breaker, rate limiting, retry with backoff, graceful shutdown |
@@ -309,7 +309,7 @@ different needs — this table is meant to help you pick the right one:
 | | **gopher-mcp** (this SDK) | [hkr04/cpp-mcp](https://github.com/hkr04/cpp-mcp) | [Neumann-Labs/mcp-cpp](https://github.com/Neumann-Labs/mcp-cpp) |
 |---|---|---|---|
 | Focus | Production / enterprise deployments | Lightweight, minimal footprint | Modern C++20 framework |
-| MCP spec version | 2025-06-18, 2025-11-25 (in progress) | 2025-03-26 | 2025-11-25 (in progress) |
+| MCP spec version | 2025-06-18, 2025-11-25, 2026-07-28 (in progress) | 2025-03-26 | 2025-11-25 (in progress) |
 | C++ standard | C++14 / 17 / 20 | C++17 | C++20 |
 | Transports | stdio, HTTP+SSE, HTTPS, Streamable HTTP, WebSocket, TCP | stdio, HTTP+SSE | stdio, HTTP |
 | Client + server | Yes | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ different needs — this table is meant to help you pick the right one:
 | | **gopher-mcp** (this SDK) | [hkr04/cpp-mcp](https://github.com/hkr04/cpp-mcp) | [Neumann-Labs/mcp-cpp](https://github.com/Neumann-Labs/mcp-cpp) |
 |---|---|---|---|
 | Focus | Production / enterprise deployments | Lightweight, minimal footprint | Modern C++20 framework |
-| MCP spec version | 2025-06-18 | 2025-03-26 | 2025-11-25 (in progress) |
+| MCP spec version | 2025-06-18, 2025-11-25 (in progress) | 2025-03-26 | 2025-11-25 (in progress) |
 | C++ standard | C++14 / 17 / 20 | C++17 | C++20 |
 | Transports | stdio, HTTP+SSE, HTTPS, Streamable HTTP, WebSocket, TCP | stdio, HTTP+SSE | stdio, HTTP |
 | Client + server | Yes | Yes | Yes |
@@ -371,7 +371,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. Issues and pull requests 
 Using this MCP C++ SDK in your product or project? We'd love to list you
 here — open a pull request or issue to add yourself.
 
-- [Gopher Security](https://gopher.security) - MCP-native zero-trust security platform
+- [Gopher Security](https://gopher.security) - MCP-native AI security platform
 
 ## Keywords & Search Terms
 


### PR DESCRIPTION
Improves discoverability of the SDK for people evaluating C++ MCP implementations.

- Add a factual comparison table of C++ MCP SDKs (gopher-mcp, hkr04/cpp-mcp, Neumann-Labs/mcp-cpp): spec version, C++ standard, transports, TLS, resilience, observability, language bindings, license. Claims about other SDKs were verified against their repos.
- Add an FAQ entry pointing to the comparison.
- Add an Adopters section inviting users to list themselves, seeded with Gopher Security.

Repo metadata was also updated separately (topics now include mcp-cpp and cpp-mcp; description mentions servers/clients and all transports).