### PR TITLE
Support streamable HTTP elicitation routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+
+## [0.1.16] - 2026-08-30
+
+### Added
+
 - `McpServer::askClient` sends a request to a client mid-request and delivers
   its answer to a callback, bounded by a deadline. `ResponseStream::sendRequest`
   carries the question down the stream the answer will arrive on.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ Please create a build directory and run cmake from there:
 You may need to remove CMakeCache.txt and CMakeFiles/")
 endif()
 
-project(gopher-mcp VERSION 0.1.15 LANGUAGES C CXX)
+project(gopher-mcp VERSION 0.1.16 LANGUAGES C CXX)
 
 # Set library version for shared libraries
 set(GOPHER_MCP_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})

--- a/include/mcp/builders.h
+++ b/include/mcp/builders.h
@@ -244,6 +244,29 @@ class ClientCapabilitiesBuilder
     return *this;
   }
 
+  ClientCapabilitiesBuilder& elicitation(bool enabled) {
+    if (enabled) {
+      ElicitationCapability capability;
+      capability.form = mcp::make_optional(EmptyCapability());
+      value_.elicitation = mcp::make_optional(capability);
+    } else {
+      value_.elicitation = nullopt;
+    }
+    return *this;
+  }
+
+  ClientCapabilitiesBuilder& elicitationUrl(bool enabled) {
+    if (enabled) {
+      if (!value_.elicitation) {
+        value_.elicitation = mcp::make_optional(ElicitationCapability());
+      }
+      value_.elicitation->url = mcp::make_optional(EmptyCapability());
+    } else if (value_.elicitation) {
+      value_.elicitation->url = nullopt;
+    }
+    return *this;
+  }
+
   ClientCapabilitiesBuilder& resources(bool enabled) {
     if (!value_.experimental) {
       value_.experimental = mcp::make_optional(Metadata());

--- a/include/mcp/filter/server_connection_mode.h
+++ b/include/mcp/filter/server_connection_mode.h
@@ -2,16 +2,18 @@
  * @file server_connection_mode.h
  * @brief Server-side connection mode state machine
  *
- * Manages the per-connection mode determination for MCP server filters.
- * Each accepted connection is classified into exactly one mode during
- * HTTP header parsing, and the mode is immutable for the connection's
- * lifetime. This replaces the ad-hoc boolean flags (sse_server_mode_,
+ * Manages server-side mode determination for MCP server filters. Each HTTP
+ * request is classified into exactly one mode during header parsing. Plain
+ * HTTP and callback-proxy requests reset after message completion so a
+ * keep-alive connection can later become a Streamable HTTP event stream; an
+ * SSE stream owns the connection until close. This replaces the ad-hoc boolean
+ * flags (sse_server_mode_,
  * sse_writing_handshake_, sse_headers_written_) with a validated state
  * machine that provides transition history and observable callbacks.
  *
  * Design principles:
  * - Thread-confined to dispatcher thread (lock-free, no mutex)
- * - Mode determined once (Undetermined -> PlainHttp|SseStream|CallbackProxy)
+ * - Mode determined once per HTTP request
  * - RAII HandshakeWriteGuard for the reentrancy guard pattern
  * - Observable via callbacks for debugging and logging
  * - Per-connection instance owned by the filter via unique_ptr
@@ -218,6 +220,11 @@ class ServerConnectionMode {
 
   std::chrono::milliseconds getTimeInCurrentMode() const;
   uint64_t getTotalTransitions() const { return total_transitions_; }
+
+  // Reset request-scoped modes after HTTP message completion so keep-alive
+  // sockets can carry a later request with a different mode. No-op for
+  // SseStream because an event stream owns the connection until close.
+  void resetForNextRequest();
 
   // ===== Utility =====
 

--- a/include/mcp/filter/sse_session_registry.h
+++ b/include/mcp/filter/sse_session_registry.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "mcp/event/event_loop.h"
 #include "mcp/network/connection.h"
@@ -57,6 +58,20 @@ class SseSessionRegistry {
   std::string registerSession(const std::string& session_id,
                               network::Connection* connection);
 
+  using StreamWriter = std::function<bool(const std::string&)>;
+
+  // Record an SSE stream connection with a generated session ID and explicit
+  // event-stream writer.
+  std::string registerSession(network::Connection* connection,
+                              StreamWriter writer);
+
+  // Record an SSE stream connection with an explicit writer that emits bytes
+  // already framed for the event stream. This avoids re-entering the generic
+  // HTTP response path for server-initiated messages.
+  std::string registerSession(const std::string& session_id,
+                              network::Connection* connection,
+                              StreamWriter writer);
+
   // Drop a session. Safe to call with an unknown ID (no-op).
   void removeSession(const std::string& session_id);
 
@@ -106,8 +121,13 @@ class SseSessionRegistry {
   bool hasSession(const std::string& session_id) const;
 
  private:
+  struct SessionEntry {
+    network::Connection* connection{nullptr};
+    StreamWriter writer;
+  };
+
   event::Dispatcher& dispatcher_;
-  std::map<std::string, network::Connection*> sessions_;
+  std::map<std::string, SessionEntry> sessions_;
   uint64_t next_id_{1};
   SessionClosedCallback session_closed_callback_;
 };

--- a/include/mcp/filter/sse_session_registry.h
+++ b/include/mcp/filter/sse_session_registry.h
@@ -51,6 +51,12 @@ class SseSessionRegistry {
   // filter's destructor does this.
   std::string registerSession(network::Connection* connection);
 
+  // Record an SSE stream connection under a caller-provided stable session ID.
+  // Used by Streamable HTTP, where the client repeats Mcp-Session-Id on the
+  // GET event stream and POST request connections.
+  std::string registerSession(const std::string& session_id,
+                              network::Connection* connection);
+
   // Drop a session. Safe to call with an unknown ID (no-op).
   void removeSession(const std::string& session_id);
 

--- a/include/mcp/filter/sse_session_registry.h
+++ b/include/mcp/filter/sse_session_registry.h
@@ -52,24 +52,11 @@ class SseSessionRegistry {
   // filter's destructor does this.
   std::string registerSession(network::Connection* connection);
 
-  // Record an SSE stream connection under a caller-provided stable session ID.
-  // Used by Streamable HTTP, where the client repeats Mcp-Session-Id on the
-  // GET event stream and POST request connections.
-  std::string registerSession(const std::string& session_id,
-                              network::Connection* connection);
-
   using StreamWriter = std::function<bool(const std::string&)>;
 
   // Record an SSE stream connection with a generated session ID and explicit
   // event-stream writer.
   std::string registerSession(network::Connection* connection,
-                              StreamWriter writer);
-
-  // Record an SSE stream connection with an explicit writer that emits bytes
-  // already framed for the event stream. This avoids re-entering the generic
-  // HTTP response path for server-initiated messages.
-  std::string registerSession(const std::string& session_id,
-                              network::Connection* connection,
                               StreamWriter writer);
 
   // Drop a session. Safe to call with an unknown ID (no-op).

--- a/include/mcp/json/json_serialization_mcp_traits.h
+++ b/include/mcp/json/json_serialization_mcp_traits.h
@@ -91,8 +91,7 @@ ServerCapabilities deserialize_ServerCapabilities(const JsonValue& json);
 JsonValue serialize_ClientCapabilities(const ClientCapabilities& value);
 ClientCapabilities deserialize_ClientCapabilities(const JsonValue& json);
 
-JsonValue serialize_ElicitationCapability(
-    const ElicitationCapability& value);
+JsonValue serialize_ElicitationCapability(const ElicitationCapability& value);
 ElicitationCapability deserialize_ElicitationCapability(const JsonValue& json);
 
 JsonValue serialize_RootsCapability(const RootsCapability& value);

--- a/include/mcp/json/json_serialization_mcp_traits.h
+++ b/include/mcp/json/json_serialization_mcp_traits.h
@@ -91,6 +91,10 @@ ServerCapabilities deserialize_ServerCapabilities(const JsonValue& json);
 JsonValue serialize_ClientCapabilities(const ClientCapabilities& value);
 ClientCapabilities deserialize_ClientCapabilities(const JsonValue& json);
 
+JsonValue serialize_ElicitationCapability(
+    const ElicitationCapability& value);
+ElicitationCapability deserialize_ElicitationCapability(const JsonValue& json);
+
 JsonValue serialize_RootsCapability(const RootsCapability& value);
 RootsCapability deserialize_RootsCapability(const JsonValue& json);
 
@@ -363,6 +367,8 @@ SERIALIZE_TRAIT(ServerCapabilities)
 DESERIALIZE_TRAIT(ServerCapabilities)
 SERIALIZE_TRAIT(ClientCapabilities)
 DESERIALIZE_TRAIT(ClientCapabilities)
+SERIALIZE_TRAIT(ElicitationCapability)
+DESERIALIZE_TRAIT(ElicitationCapability)
 SERIALIZE_TRAIT(RootsCapability)
 DESERIALIZE_TRAIT(RootsCapability)
 SERIALIZE_TRAIT(ResourcesCapability)

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -1207,11 +1207,10 @@ class McpServer : public application::ApplicationBase,
   // or with an error response when the deadline passes first. Waiting on the
   // returned future from the dispatcher thread will deadlock the response path.
   // HTTP/SSE sessions require an active SSE stream for server push.
-  std::future<jsonrpc::Response> sendRequest(const std::string& session_id,
-                                             const jsonrpc::Request& request,
-                                             std::chrono::milliseconds timeout =
-                                                 std::chrono::milliseconds(
-                                                     30000));
+  std::future<jsonrpc::Response> sendRequest(
+      const std::string& session_id,
+      const jsonrpc::Request& request,
+      std::chrono::milliseconds timeout = std::chrono::milliseconds(30000));
 
   bool sessionSupportsElicitation(const std::string& session_id,
                                   const std::string& mode) const;

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -1203,10 +1203,15 @@ class McpServer : public application::ApplicationBase,
                               const jsonrpc::Notification& notification);
 
   // Send a server-initiated request to a specific session and resolve the
-  // returned future when that client sends the matching JSON-RPC response.
+  // returned future when that client sends the matching JSON-RPC response,
+  // or with an error response when the deadline passes first. Waiting on the
+  // returned future from the dispatcher thread will deadlock the response path.
   // HTTP/SSE sessions require an active SSE stream for server push.
   std::future<jsonrpc::Response> sendRequest(const std::string& session_id,
-                                             const jsonrpc::Request& request);
+                                             const jsonrpc::Request& request,
+                                             std::chrono::milliseconds timeout =
+                                                 std::chrono::milliseconds(
+                                                     30000));
 
   bool sessionSupportsElicitation(const std::string& session_id,
                                   const std::string& mode) const;

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -77,6 +77,7 @@ class ResourceManager;
 class ToolRegistry;
 class PromptRegistry;
 class SessionManager;
+class SessionContext;
 
 /**
  * Server configuration
@@ -87,6 +88,8 @@ struct McpServerConfig : public application::ApplicationBase::Config {
   std::string server_name = "mcp-cpp-server";
   std::string server_version = "1.0.0";
   std::string instructions;  // Optional server instructions
+  std::function<std::string(const jsonrpc::Request&, SessionContext&)>
+      instructions_provider;
 
   // Transport configuration
   std::vector<TransportType> supported_transports = {TransportType::Stdio,
@@ -311,6 +314,20 @@ class SessionContext {
 
   const std::string& getProtocolVersion() const { return protocol_version_; }
 
+  void setNegotiatedProtocolVersion(const std::string& protocol_version) {
+    setProtocolVersion(protocol_version);
+  }
+  const std::string& getNegotiatedProtocolVersion() const {
+    return getProtocolVersion();
+  }
+
+  void setClientCapabilities(const ClientCapabilities& capabilities) {
+    client_capabilities_ = capabilities;
+  }
+  const ClientCapabilities& getClientCapabilities() const {
+    return client_capabilities_;
+  }
+
   // Request-scoped metadata: the in-flight request's params._meta, carried as
   // its stringified-JSON form (consistent with how nested arguments are
   // represented in Metadata). Set immediately before each tool handler is
@@ -354,6 +371,7 @@ class SessionContext {
   std::chrono::steady_clock::time_point last_activity_;
   optional<Implementation> client_info_;
   std::string protocol_version_;        // negotiated at initialize
+  ClientCapabilities client_capabilities_;
   optional<std::string> request_meta_;  // params._meta of the in-flight request
 
   mutable std::mutex mutex_;
@@ -1118,6 +1136,10 @@ class McpServer : public application::ApplicationBase,
       std::function<void(const jsonrpc::Notification&, SessionContext&)>
           handler);
 
+  // Update initialize instructions returned to future clients. Useful for
+  // gateways that discover backend instructions after server construction.
+  void setInstructions(const std::string& instructions);
+
   // Resource management — register with a read handler for resources/read
   void registerResource(
       const Resource& resource,
@@ -1185,6 +1207,9 @@ class McpServer : public application::ApplicationBase,
   // HTTP/SSE sessions require an active SSE stream for server push.
   std::future<jsonrpc::Response> sendRequest(const std::string& session_id,
                                              const jsonrpc::Request& request);
+
+  bool sessionSupportsElicitation(const std::string& session_id,
+                                  const std::string& mode) const;
 
   // Broadcast notification to all sessions
   void broadcastNotification(const jsonrpc::Notification& notification);
@@ -1488,6 +1513,7 @@ class McpServer : public application::ApplicationBase,
   };
 
   McpServerConfig config_;
+  mutable std::mutex config_mutex_;
   McpServerStats server_stats_;
   std::unique_ptr<ServerProtocolCallbacks> protocol_callbacks_;
   std::shared_ptr<filter::MetricsFilter> metrics_filter_;

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -370,7 +370,7 @@ class SessionContext {
   std::chrono::steady_clock::time_point created_time_;
   std::chrono::steady_clock::time_point last_activity_;
   optional<Implementation> client_info_;
-  std::string protocol_version_;        // negotiated at initialize
+  std::string protocol_version_;  // negotiated at initialize
   ClientCapabilities client_capabilities_;
   optional<std::string> request_meta_;  // params._meta of the in-flight request
 

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <chrono>
 #include <functional>
+#include <future>
 #include <list>
 #include <map>
 #include <memory>
@@ -1179,6 +1180,12 @@ class McpServer : public application::ApplicationBase,
   VoidResult sendNotification(const std::string& session_id,
                               const jsonrpc::Notification& notification);
 
+  // Send a server-initiated request to a specific session and resolve the
+  // returned future when that client sends the matching JSON-RPC response.
+  // HTTP/SSE sessions require an active SSE stream for server push.
+  std::future<jsonrpc::Response> sendRequest(const std::string& session_id,
+                                             const jsonrpc::Request& request);
+
   // Broadcast notification to all sessions
   void broadcastNotification(const jsonrpc::Notification& notification);
 
@@ -1347,6 +1354,9 @@ class McpServer : public application::ApplicationBase,
   VoidResult sendNotificationToSession(
       const SessionManager::SessionPtr& session,
       const jsonrpc::Notification& notification);
+
+  VoidResult sendRequestToSession(const SessionManager::SessionPtr& session,
+                                  const jsonrpc::Request& request);
 
   // Internal method to perform actual listening (called from dispatcher thread)
   void performListen();

--- a/include/mcp/types.h
+++ b/include/mcp/types.h
@@ -820,11 +820,17 @@ struct RootsCapability {
   optional<EmptyCapability> listChanged;
 };
 
+struct ElicitationCapability {
+  optional<EmptyCapability> form;
+  optional<EmptyCapability> url;
+};
+
 // Capability types
 struct ClientCapabilities {
   optional<Metadata> experimental;
   optional<SamplingParams> sampling;
   optional<RootsCapability> roots;
+  optional<ElicitationCapability> elicitation;
 
   ClientCapabilities() = default;
 };

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -763,6 +763,7 @@ class HttpSseJsonRpcProtocolFilter
       if (server_mode_ && !server_mode_->isSseStream() &&
           server_mode_->currentMode() != ServerConnMode::Undetermined) {
         server_mode_->resetForNextRequest();
+        clearPerRequestSessionIds();
       }
 
       auto accept_it = headers.find("accept");
@@ -873,6 +874,7 @@ class HttpSseJsonRpcProtocolFilter
         if (server_mode_) {
           server_mode_->handleEvent(ServerConnEvent::CallbackPostDetected);
         }
+        streamable_http_session_id_.clear();
         sse_callback_session_id_ = path.substr(cb_pos + callback_prefix.size());
         GOPHER_LOG_DEBUG("SSE callback POST: session={}",
                          sse_callback_session_id_);
@@ -903,6 +905,7 @@ class HttpSseJsonRpcProtocolFilter
           server_mode_->currentMode() == ServerConnMode::Undetermined) {
         server_mode_->handleEvent(ServerConnEvent::PlainHttpDetected);
       }
+      sse_callback_session_id_.clear();
       streamable_http_session_id_.clear();
       auto session_it = headers.find("mcp-session-id");
       if (session_it != headers.end()) {
@@ -1111,6 +1114,7 @@ class HttpSseJsonRpcProtocolFilter
 
     if (server_mode_ && !server_mode_->isSseStream()) {
       server_mode_->resetForNextRequest();
+      clearPerRequestSessionIds();
     }
   }
 
@@ -1236,7 +1240,8 @@ class HttpSseJsonRpcProtocolFilter
     }
 
     const std::string& transportSessionId() const override {
-      if (!parent_.sse_callback_session_id_.empty()) {
+      if (parent_.server_mode_ && parent_.server_mode_->isCallbackProxy() &&
+          !parent_.sse_callback_session_id_.empty()) {
         return parent_.sse_callback_session_id_;
       }
       return parent_.streamable_http_session_id_;
@@ -1974,6 +1979,11 @@ class HttpSseJsonRpcProtocolFilter
   // durable request-session identity for POST /mcp clients that do not use the
   // SSE callback path.
   std::string streamable_http_session_id_;
+
+  void clearPerRequestSessionIds() {
+    sse_callback_session_id_.clear();
+    streamable_http_session_id_.clear();
+  }
 
   // Messages queued during SSE endpoint negotiation (client mode only).
   // Drained once the state machine reaches EndpointReceived.

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -760,6 +760,11 @@ class HttpSseJsonRpcProtocolFilter
         path = path.substr(0, qpos);
       }
 
+      if (server_mode_ && !server_mode_->isSseStream() &&
+          server_mode_->currentMode() != ServerConnMode::Undetermined) {
+        server_mode_->resetForNextRequest();
+      }
+
       auto accept_it = headers.find("accept");
       const bool accepts_sse =
           accept_it != headers.end() &&
@@ -783,8 +788,11 @@ class HttpSseJsonRpcProtocolFilter
             session_it != headers.end() && !session_it->second.empty()
                 ? session_it->second
                 : nextStreamableHttpSessionId();
-        sse_registry_->registerSession(sse_session_id_,
-                                       &write_callbacks_->connection());
+        sse_registry_->registerSession(
+            sse_session_id_, &write_callbacks_->connection(),
+            [this](const std::string& json_data) {
+              return writeSseEventToOpenStream(json_data);
+            });
 
         std::ostringstream sse_response;
         sse_response << "HTTP/1.1 200 OK\r\n";
@@ -793,7 +801,9 @@ class HttpSseJsonRpcProtocolFilter
         sse_response << "Connection: keep-alive\r\n";
         sse_response << "Mcp-Session-Id: " << sse_session_id_ << "\r\n";
         sse_response << "Access-Control-Allow-Origin: *\r\n";
+        sse_response << "X-Accel-Buffering: no\r\n";
         sse_response << "\r\n";
+        sse_response << ": stream open\n\n";
 
         const std::string response_str = sse_response.str();
         OwnedBuffer response_buffer;
@@ -817,8 +827,11 @@ class HttpSseJsonRpcProtocolFilter
           server_mode_->handleEvent(ServerConnEvent::SseGetDetected);
         }
         client_accepts_sse_ = true;
-        sse_session_id_ =
-            sse_registry_->registerSession(&write_callbacks_->connection());
+        sse_session_id_ = sse_registry_->registerSession(
+            &write_callbacks_->connection(),
+            [this](const std::string& json_data) {
+              return writeSseEventToOpenStream(json_data);
+            });
 
         // Build the callback URL the client will POST future requests
         // to. If an external URL is configured (reverse-proxy case) we
@@ -1144,6 +1157,10 @@ class HttpSseJsonRpcProtocolFilter
     // The stream this response was, if it was one, is over. Read after
     // the flush above, which asks whether it was.
     reading_event_stream_ = false;
+
+    if (server_mode_ && !server_mode_->isSseStream()) {
+      server_mode_->resetForNextRequest();
+    }
   }
 
   void onError(const std::string& error) override {
@@ -1652,6 +1669,49 @@ class HttpSseJsonRpcProtocolFilter
     pending_messages_.clear();
     GOPHER_LOG_DEBUG(
         "HttpSseJsonRpcProtocolFilter: Finished processing pending messages");
+  }
+
+  bool writeSseEventToOpenStream(const std::string& json_data) {
+    if (!write_callbacks_) {
+      GOPHER_LOG_WARN(
+          "SSE stream write rejected: no write callbacks (session={})",
+          sse_session_id_);
+      return false;
+    }
+    if (!server_mode_) {
+      GOPHER_LOG_WARN("SSE stream write rejected: no server mode (session={})",
+                      sse_session_id_);
+      return false;
+    }
+    if (!server_mode_->isSseStream()) {
+      GOPHER_LOG_WARN(
+          "SSE stream write rejected: mode={} session={}",
+          ServerConnectionMode::getModeName(server_mode_->currentMode()),
+          sse_session_id_);
+      return false;
+    }
+    if (write_callbacks_->connection().state() !=
+        network::ConnectionState::Open) {
+      GOPHER_LOG_WARN(
+          "SSE stream write rejected: connection state={} session={}",
+          static_cast<int>(write_callbacks_->connection().state()),
+          sse_session_id_);
+      return false;
+    }
+
+    std::string event;
+    event.reserve(json_data.size() + 8);
+    event.append("data: ");
+    event.append(json_data);
+    event.append("\n\n");
+
+    OwnedBuffer buffer;
+    buffer.add(event.c_str(), event.length());
+    {
+      HandshakeWriteGuard guard(*server_mode_);
+      write_callbacks_->connection().write(buffer, /*end_stream=*/false);
+    }
+    return true;
   }
 
   /**

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -770,58 +770,9 @@ class HttpSseJsonRpcProtocolFilter
           accept_it != headers.end() &&
           accept_it->second.find("text/event-stream") != std::string::npos;
 
-      // ── GET {configured_rpc_path_} + Accept: text/event-stream →
-      // open a Streamable HTTP event stream for an existing Mcp-Session-Id.
-      //
-      // Streamable HTTP clients such as Postman keep server-initiated
-      // requests on this event stream while sending client requests and
-      // responses as POSTs to the same /mcp endpoint with Mcp-Session-Id.
-      if (method == "GET" && path == configured_rpc_path_ && accepts_sse &&
-          sse_registry_ && write_callbacks_) {
-        if (server_mode_) {
-          server_mode_->handleEvent(ServerConnEvent::SseGetDetected);
-        }
-        client_accepts_sse_ = true;
-
-        auto session_it = headers.find("mcp-session-id");
-        sse_session_id_ =
-            session_it != headers.end() && !session_it->second.empty()
-                ? session_it->second
-                : nextStreamableHttpSessionId();
-        sse_registry_->registerSession(
-            sse_session_id_, &write_callbacks_->connection(),
-            [this](const std::string& json_data) {
-              return writeSseEventToOpenStream(json_data);
-            });
-
-        std::ostringstream sse_response;
-        sse_response << "HTTP/1.1 200 OK\r\n";
-        sse_response << "Content-Type: text/event-stream\r\n";
-        sse_response << "Cache-Control: no-cache\r\n";
-        sse_response << "Connection: keep-alive\r\n";
-        sse_response << "Mcp-Session-Id: " << sse_session_id_ << "\r\n";
-        sse_response << "Access-Control-Allow-Origin: *\r\n";
-        sse_response << "X-Accel-Buffering: no\r\n";
-        sse_response << "\r\n";
-        sse_response << ": stream open\n\n";
-
-        const std::string response_str = sse_response.str();
-        OwnedBuffer response_buffer;
-        response_buffer.add(response_str.c_str(), response_str.length());
-        {
-          HandshakeWriteGuard guard(*server_mode_);
-          write_callbacks_->connection().write(response_buffer, false);
-        }
-        server_mode_->handleEvent(ServerConnEvent::SseHeadersWritten);
-
-        GOPHER_LOG_INFO("Streamable HTTP event stream opened: session={}",
-                        sse_session_id_);
-        return;
-      }
-
       // ── GET {configured_sse_path_} → open an SSE stream.
-      if (method == "GET" && path == configured_sse_path_ && sse_registry_ &&
-          write_callbacks_) {
+      if (method == "GET" && path == configured_sse_path_ &&
+          path != configured_rpc_path_ && sse_registry_ && write_callbacks_) {
         // Determine connection mode as SSE stream.
         if (server_mode_) {
           server_mode_->handleEvent(ServerConnEvent::SseGetDetected);

--- a/src/filter/http_sse_filter_chain_factory.cc
+++ b/src/filter/http_sse_filter_chain_factory.cc
@@ -52,6 +52,7 @@
 
 #include "mcp/filter/http_sse_filter_chain_factory.h"
 
+#include <atomic>
 #include <cassert>
 #include <cstdint>
 #include <ctime>
@@ -114,6 +115,11 @@ static std::string requestIdToString(const RequestId& id) {
     return std::to_string(get<int64_t>(id));
   }
   return "<unknown>";
+}
+
+static std::string nextStreamableHttpSessionId() {
+  static std::atomic<uint64_t> next_id{1};
+  return "streamable_" + std::to_string(next_id.fetch_add(1));
 }
 
 class HttpSseJsonRpcProtocolFilter
@@ -673,7 +679,12 @@ class HttpSseJsonRpcProtocolFilter
     GOPHER_LOG_DEBUG(
         "HttpSseJsonRpcProtocolFilter::onWrite - calling http_filter");
     // HTTP filter adds headers/framing for normal HTTP responses
-    return http_filter_->onWrite(data, end_stream);
+    status = http_filter_->onWrite(data, end_stream);
+    if (status != network::FilterStatus::StopIteration && is_server_ &&
+        !streamable_http_session_id_.empty() && data.length() > 0) {
+      addStreamableHttpSessionHeader(data);
+    }
+    return status;
   }
 
   void initializeReadFilterCallbacks(
@@ -747,6 +758,55 @@ class HttpSseJsonRpcProtocolFilter
       size_t qpos = path.find('?');
       if (qpos != std::string::npos) {
         path = path.substr(0, qpos);
+      }
+
+      auto accept_it = headers.find("accept");
+      const bool accepts_sse =
+          accept_it != headers.end() &&
+          accept_it->second.find("text/event-stream") != std::string::npos;
+
+      // ── GET {configured_rpc_path_} + Accept: text/event-stream →
+      // open a Streamable HTTP event stream for an existing Mcp-Session-Id.
+      //
+      // Streamable HTTP clients such as Postman keep server-initiated
+      // requests on this event stream while sending client requests and
+      // responses as POSTs to the same /mcp endpoint with Mcp-Session-Id.
+      if (method == "GET" && path == configured_rpc_path_ && accepts_sse &&
+          sse_registry_ && write_callbacks_) {
+        if (server_mode_) {
+          server_mode_->handleEvent(ServerConnEvent::SseGetDetected);
+        }
+        client_accepts_sse_ = true;
+
+        auto session_it = headers.find("mcp-session-id");
+        sse_session_id_ =
+            session_it != headers.end() && !session_it->second.empty()
+                ? session_it->second
+                : nextStreamableHttpSessionId();
+        sse_registry_->registerSession(sse_session_id_,
+                                       &write_callbacks_->connection());
+
+        std::ostringstream sse_response;
+        sse_response << "HTTP/1.1 200 OK\r\n";
+        sse_response << "Content-Type: text/event-stream\r\n";
+        sse_response << "Cache-Control: no-cache\r\n";
+        sse_response << "Connection: keep-alive\r\n";
+        sse_response << "Mcp-Session-Id: " << sse_session_id_ << "\r\n";
+        sse_response << "Access-Control-Allow-Origin: *\r\n";
+        sse_response << "\r\n";
+
+        const std::string response_str = sse_response.str();
+        OwnedBuffer response_buffer;
+        response_buffer.add(response_str.c_str(), response_str.length());
+        {
+          HandshakeWriteGuard guard(*server_mode_);
+          write_callbacks_->connection().write(response_buffer, false);
+        }
+        server_mode_->handleEvent(ServerConnEvent::SseHeadersWritten);
+
+        GOPHER_LOG_INFO("Streamable HTTP event stream opened: session={}",
+                        sse_session_id_);
+        return;
       }
 
       // ── GET {configured_sse_path_} → open an SSE stream.
@@ -884,7 +944,6 @@ class HttpSseJsonRpcProtocolFilter
       if (session_it != headers.end()) {
         streamable_http_session_id_ = session_it->second;
       }
-
       // The protocol version header only became required after a certain
       // revision, so a request without one identifies a peer speaking the
       // revision before it.
@@ -892,9 +951,11 @@ class HttpSseJsonRpcProtocolFilter
       request_protocol_version_ = version_it != headers.end()
                                       ? version_it->second
                                       : protocol::kLegacyAssumedVersion;
-      auto accept = headers.find("accept");
-      if (accept != headers.end() &&
-          accept->second.find("text/event-stream") != std::string::npos) {
+      if (streamable_http_session_id_.empty() && method == "POST" &&
+          path == configured_rpc_path_) {
+        streamable_http_session_id_ = nextStreamableHttpSessionId();
+      }
+      if (accepts_sse) {
         client_accepts_sse_ = true;
         GOPHER_LOG_DEBUG("HttpSseJsonRpcProtocolFilter: client accepts SSE");
       }
@@ -1806,6 +1867,29 @@ class HttpSseJsonRpcProtocolFilter
     if (route_registration_callback_) {
       route_registration_callback_(routing_filter_.get());
     }
+  }
+
+  void addStreamableHttpSessionHeader(Buffer& data) {
+    const size_t len = data.length();
+    std::string http_response(static_cast<const char*>(data.linearize(len)),
+                              len);
+    if (http_response.compare(0, 5, "HTTP/") != 0 ||
+        http_response.find("\r\nMcp-Session-Id:") != std::string::npos ||
+        http_response.find("\r\nmcp-session-id:") != std::string::npos) {
+      return;
+    }
+
+    const std::string marker = "\r\n\r\n";
+    const auto header_end = http_response.find(marker);
+    if (header_end == std::string::npos) {
+      return;
+    }
+
+    const std::string header =
+        "\r\nMcp-Session-Id: " + streamable_http_session_id_;
+    http_response.insert(header_end, header);
+    data.drain(len);
+    data.add(http_response.c_str(), http_response.length());
   }
 
   /**

--- a/src/filter/server_connection_mode.cc
+++ b/src/filter/server_connection_mode.cc
@@ -168,6 +168,23 @@ std::chrono::milliseconds ServerConnectionMode::getTimeInCurrentMode() const {
       now - mode_entry_time_);
 }
 
+void ServerConnectionMode::resetForNextRequest() {
+  assertInDispatcherThread();
+
+  if (current_mode_ == ServerConnMode::SseStream ||
+      current_mode_ == ServerConnMode::Undetermined ||
+      current_mode_ == ServerConnMode::Closed) {
+    return;
+  }
+
+  GOPHER_LOG_DEBUG("ServerConnectionMode: resetting {} for next request",
+                   getModeName(current_mode_));
+  current_mode_ = ServerConnMode::Undetermined;
+  mode_entry_time_ = std::chrono::steady_clock::now();
+  sse_headers_written_ = false;
+  transition_in_progress_ = false;
+}
+
 // ===== Utility =====
 
 std::string ServerConnectionMode::getModeName(ServerConnMode mode) {

--- a/src/filter/sse_session_registry.cc
+++ b/src/filter/sse_session_registry.cc
@@ -19,9 +19,8 @@ std::string SseSessionRegistry::registerSession(
   return registerSession(session_id, connection);
 }
 
-std::string SseSessionRegistry::registerSession(
-    network::Connection* connection,
-    StreamWriter writer) {
+std::string SseSessionRegistry::registerSession(network::Connection* connection,
+                                                StreamWriter writer) {
   assert(dispatcher_.isThreadSafe() &&
          "SseSessionRegistry::registerSession off-dispatcher-thread");
   std::string session_id = "client_" + std::to_string(next_id_++);
@@ -33,10 +32,9 @@ std::string SseSessionRegistry::registerSession(
   return registerSession(session_id, connection, nullptr);
 }
 
-std::string SseSessionRegistry::registerSession(
-    const std::string& session_id,
-    network::Connection* connection,
-    StreamWriter writer) {
+std::string SseSessionRegistry::registerSession(const std::string& session_id,
+                                                network::Connection* connection,
+                                                StreamWriter writer) {
   assert(dispatcher_.isThreadSafe() &&
          "SseSessionRegistry::registerSession off-dispatcher-thread");
   sessions_[session_id] = SessionEntry{connection, std::move(writer)};

--- a/src/filter/sse_session_registry.cc
+++ b/src/filter/sse_session_registry.cc
@@ -16,7 +16,10 @@ std::string SseSessionRegistry::registerSession(
   assert(dispatcher_.isThreadSafe() &&
          "SseSessionRegistry::registerSession off-dispatcher-thread");
   std::string session_id = "client_" + std::to_string(next_id_++);
-  return registerSession(session_id, connection);
+  sessions_[session_id] = SessionEntry{connection, nullptr};
+  GOPHER_LOG_INFO("SSE session registered: {} (total={})", session_id,
+                  sessions_.size());
+  return session_id;
 }
 
 std::string SseSessionRegistry::registerSession(network::Connection* connection,
@@ -24,19 +27,6 @@ std::string SseSessionRegistry::registerSession(network::Connection* connection,
   assert(dispatcher_.isThreadSafe() &&
          "SseSessionRegistry::registerSession off-dispatcher-thread");
   std::string session_id = "client_" + std::to_string(next_id_++);
-  return registerSession(session_id, connection, std::move(writer));
-}
-
-std::string SseSessionRegistry::registerSession(
-    const std::string& session_id, network::Connection* connection) {
-  return registerSession(session_id, connection, nullptr);
-}
-
-std::string SseSessionRegistry::registerSession(const std::string& session_id,
-                                                network::Connection* connection,
-                                                StreamWriter writer) {
-  assert(dispatcher_.isThreadSafe() &&
-         "SseSessionRegistry::registerSession off-dispatcher-thread");
   sessions_[session_id] = SessionEntry{connection, std::move(writer)};
   GOPHER_LOG_INFO("SSE session registered: {} (total={})", session_id,
                   sessions_.size());

--- a/src/filter/sse_session_registry.cc
+++ b/src/filter/sse_session_registry.cc
@@ -20,10 +20,26 @@ std::string SseSessionRegistry::registerSession(
 }
 
 std::string SseSessionRegistry::registerSession(
-    const std::string& session_id, network::Connection* connection) {
+    network::Connection* connection,
+    StreamWriter writer) {
   assert(dispatcher_.isThreadSafe() &&
          "SseSessionRegistry::registerSession off-dispatcher-thread");
-  sessions_[session_id] = connection;
+  std::string session_id = "client_" + std::to_string(next_id_++);
+  return registerSession(session_id, connection, std::move(writer));
+}
+
+std::string SseSessionRegistry::registerSession(
+    const std::string& session_id, network::Connection* connection) {
+  return registerSession(session_id, connection, nullptr);
+}
+
+std::string SseSessionRegistry::registerSession(
+    const std::string& session_id,
+    network::Connection* connection,
+    StreamWriter writer) {
+  assert(dispatcher_.isThreadSafe() &&
+         "SseSessionRegistry::registerSession off-dispatcher-thread");
+  sessions_[session_id] = SessionEntry{connection, std::move(writer)};
   GOPHER_LOG_INFO("SSE session registered: {} (total={})", session_id,
                   sessions_.size());
   return session_id;
@@ -50,7 +66,7 @@ void SseSessionRegistry::removeConnection(network::Connection* connection) {
     return;
   }
   for (auto it = sessions_.begin(); it != sessions_.end();) {
-    if (it->second == connection) {
+    if (it->second.connection == connection) {
       const std::string session_id = it->first;
       it = sessions_.erase(it);
       GOPHER_LOG_INFO("SSE session removed on connection close: {} (total={})",
@@ -78,7 +94,8 @@ bool SseSessionRegistry::sendResponse(
                     session_id);
     return false;
   }
-  if (writing_connection != nullptr && it->second == writing_connection) {
+  if (writing_connection != nullptr &&
+      it->second.connection == writing_connection) {
     // Re-entering write() on the connection we are already writing would
     // clobber the buffer that write is holding.
     GOPHER_LOG_WARN(
@@ -87,9 +104,21 @@ bool SseSessionRegistry::sendResponse(
         session_id);
     return false;
   }
+  if (it->second.writer) {
+    const bool written = it->second.writer(json_data);
+    if (!written) {
+      GOPHER_LOG_WARN("SSE session writer rejected response routing: {}",
+                      session_id);
+    }
+    return written;
+  }
+  if (!it->second.connection) {
+    GOPHER_LOG_WARN("SSE session has no response route: {}", session_id);
+    return false;
+  }
   OwnedBuffer buffer;
   buffer.add(json_data.c_str(), json_data.length());
-  it->second->write(buffer, /*end_stream=*/false);
+  it->second.connection->write(buffer, /*end_stream=*/false);
   GOPHER_LOG_DEBUG("SSE response routed to session {} ({} bytes)", session_id,
                    json_data.size());
   return true;

--- a/src/filter/sse_session_registry.cc
+++ b/src/filter/sse_session_registry.cc
@@ -16,6 +16,13 @@ std::string SseSessionRegistry::registerSession(
   assert(dispatcher_.isThreadSafe() &&
          "SseSessionRegistry::registerSession off-dispatcher-thread");
   std::string session_id = "client_" + std::to_string(next_id_++);
+  return registerSession(session_id, connection);
+}
+
+std::string SseSessionRegistry::registerSession(
+    const std::string& session_id, network::Connection* connection) {
+  assert(dispatcher_.isThreadSafe() &&
+         "SseSessionRegistry::registerSession off-dispatcher-thread");
   sessions_[session_id] = connection;
   GOPHER_LOG_INFO("SSE session registered: {} (total={})", session_id,
                   sessions_.size());

--- a/src/filter/streamable_http_filter.cc
+++ b/src/filter/streamable_http_filter.cc
@@ -1112,6 +1112,7 @@ void StreamableHttpFilter::validateThenDispatch(
   // for want of a session would make discovery reachable only after the
   // handshake it is meant to inform.
   const bool exempt = method_name == kInitializeMethod ||
+                      method_name == "notifications/initialized" ||
                       method_name == protocol::modern::kMethodServerDiscover;
 
   if (sessions_ != nullptr && exempt && !session_id_.empty() &&

--- a/src/json/json_serialization.cc
+++ b/src/json/json_serialization.cc
@@ -1757,6 +1757,25 @@ JsonValue serialize_ClientCapabilities(const ClientCapabilities& caps) {
     builder.add("roots", to_json(caps.roots.value()));
   }
 
+  if (caps.elicitation.has_value()) {
+    builder.add("elicitation", to_json(caps.elicitation.value()));
+  }
+
+  return builder.build();
+}
+
+JsonValue serialize_ElicitationCapability(
+    const ElicitationCapability& capability) {
+  JsonObjectBuilder builder;
+
+  if (capability.form.has_value()) {
+    builder.add("form", JsonValue::object());
+  }
+
+  if (capability.url.has_value()) {
+    builder.add("url", JsonValue::object());
+  }
+
   return builder.build();
 }
 
@@ -2739,7 +2758,33 @@ ClientCapabilities deserialize_ClientCapabilities(const JsonValue& json) {
     caps.roots = from_json<RootsCapability>(json["roots"]);
   }
 
+  if (json.contains("elicitation")) {
+    caps.elicitation = from_json<ElicitationCapability>(json["elicitation"]);
+  }
+
   return caps;
+}
+
+ElicitationCapability deserialize_ElicitationCapability(const JsonValue& json) {
+  ElicitationCapability capability;
+
+  if (!json.isObject()) {
+    return capability;
+  }
+
+  if (json.contains("form")) {
+    capability.form = EmptyCapability();
+  }
+
+  if (json.contains("url")) {
+    capability.url = EmptyCapability();
+  }
+
+  if (!capability.form.has_value() && !capability.url.has_value()) {
+    capability.form = EmptyCapability();
+  }
+
+  return capability;
 }
 
 RootsCapability deserialize_RootsCapability(const JsonValue& json) {

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -1062,7 +1062,9 @@ VoidResult McpServer::sendRequestToSession(
 }
 
 std::future<jsonrpc::Response> McpServer::sendRequest(
-    const std::string& session_id, const jsonrpc::Request& request) {
+    const std::string& session_id,
+    const jsonrpc::Request& request,
+    std::chrono::milliseconds timeout) {
   if (!main_dispatcher_ || !main_dispatcher_->isThreadSafe()) {
     return makeReadyResponseFuture(
         request.id, jsonrpc::INTERNAL_ERROR,
@@ -1077,15 +1079,40 @@ std::future<jsonrpc::Response> McpServer::sendRequest(
 
   auto promise = std::make_shared<std::promise<jsonrpc::Response>>();
   auto future = promise->get_future();
-  client_requests_.expect(request.id, [promise](const jsonrpc::Response& r) {
-    promise->set_value(r);
-  });
+  const RequestIdKey key = requestIdKey(request.id);
+  client_requests_.expect(
+      request.id, [this, key, promise](const jsonrpc::Response& r) {
+        client_request_deadlines_.erase(key);
+        promise->set_value(r);
+      });
 
   auto sent = sendRequestToSession(session, request);
   if (holds_alternative<Error>(sent)) {
     client_requests_.forget(request.id);
     promise->set_value(
         jsonrpc::Response::make_error(request.id, get<Error>(sent)));
+    return future;
+  }
+  ++server_stats_.requests_to_clients;
+
+  if (timeout.count() > 0) {
+    auto timer = main_dispatcher_->createTimer([this, key, request, promise]() {
+      if (!client_requests_.forget(request.id)) {
+        return;
+      }
+
+      ++server_stats_.client_requests_timed_out;
+      GOPHER_LOG_WARN("No answer from the client to {} in time",
+                      requestIdKeyToString(key));
+      promise->set_value(jsonrpc::Response::make_error(
+          request.id,
+          Error(jsonrpc::INTERNAL_ERROR, "the client did not answer in time")));
+
+      main_dispatcher_->post(
+          [this, key]() { client_request_deadlines_.erase(key); });
+    });
+    timer->enableTimer(timeout);
+    client_request_deadlines_[key] = std::move(timer);
   }
 
   return future;

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -15,8 +15,8 @@
 #include "mcp/filter/http_sse_filter_chain_factory.h"
 #include "mcp/filter/json_rpc_filter_factory.h"
 #include "mcp/filter/json_rpc_protocol_filter.h"
-#include "mcp/json/json_serialization.h"
 #include "mcp/filter/sse_session_registry.h"
+#include "mcp/json/json_serialization.h"
 #include "mcp/logging/log_macros.h"
 #include "mcp/protocol/modern_era.h"
 #include "mcp/protocol/protocol_versions.h"
@@ -969,10 +969,10 @@ VoidResult McpServer::sendNotificationToSession(
     // Registry exists but the stream is gone (client disconnected between
     // lookup and send) — report failure so the caller doesn't assume
     // delivery.
-    return makeVoidError(
-        Error(jsonrpc::INTERNAL_ERROR,
-              "SSE stream gone for session " + session->getId() +
-                  " (transport " + session->getTransportSessionId() + ")"));
+    return makeVoidError(Error(jsonrpc::INTERNAL_ERROR,
+                               "SSE stream gone for session " +
+                                   session->getId() + " (transport " +
+                                   session->getTransportSessionId() + ")"));
   }
 
   // Connection-keyed session. Since the dispatch context supplies the
@@ -1039,10 +1039,10 @@ VoidResult McpServer::sendRequestToSession(
             session->getTransportSessionId(), json_str)) {
       return makeVoidSuccess();
     }
-    return makeVoidError(
-        Error(jsonrpc::INTERNAL_ERROR,
-              "SSE stream gone for session " + session->getId() +
-                  " (transport " + session->getTransportSessionId() + ")"));
+    return makeVoidError(Error(jsonrpc::INTERNAL_ERROR,
+                               "SSE stream gone for session " +
+                                   session->getId() + " (transport " +
+                                   session->getTransportSessionId() + ")"));
   }
 
   if (session->getConnection()) {
@@ -1091,14 +1091,13 @@ std::future<jsonrpc::Response> McpServer::sendRequest(
   return future;
 }
 
-bool McpServer::sessionSupportsElicitation(
-    const std::string& session_id, const std::string& mode) const {
+bool McpServer::sessionSupportsElicitation(const std::string& session_id,
+                                           const std::string& mode) const {
   auto session = session_manager_->getSession(session_id);
   if (!session) {
     return false;
   }
-  const auto& elicitation =
-      session->getClientCapabilities().elicitation;
+  const auto& elicitation = session->getClientCapabilities().elicitation;
   if (!elicitation.has_value() ||
       !protocolSupportsElicitationMode(session->getNegotiatedProtocolVersion(),
                                        mode)) {
@@ -2155,8 +2154,10 @@ jsonrpc::Response McpServer::handleInitialize(const jsonrpc::Request& request,
   if (request.params.has_value()) {
     auto params = request.params.value();
     requested_version = stringMetadataValue(params, "protocolVersion");
-    session.setClientCapabilities(clientCapabilitiesFromInitializeParams(params));
-    const std::string raw_client_info = stringMetadataValue(params, "clientInfo");
+    session.setClientCapabilities(
+        clientCapabilitiesFromInitializeParams(params));
+    const std::string raw_client_info =
+        stringMetadataValue(params, "clientInfo");
     if (!raw_client_info.empty()) {
       try {
         const json::JsonValue json = json::JsonValue::parse(raw_client_info);
@@ -2180,8 +2181,9 @@ jsonrpc::Response McpServer::handleInitialize(const jsonrpc::Request& request,
   std::vector<std::string> supported = transport::handshakeProtocolVersions(
       transport::servedProtocolVersions(config_.streamable_http));
   if (supported.empty()) {
-    supported.push_back(protocol_version.empty() ? protocol::kDefaultProtocolVersion
-                                                 : protocol_version);
+    supported.push_back(protocol_version.empty()
+                            ? protocol::kDefaultProtocolVersion
+                            : protocol_version);
   }
 
   const std::string negotiated =

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -29,6 +29,22 @@
 
 namespace mcp {
 namespace server {
+namespace {
+
+std::string requestIdToString(const RequestId& id) {
+  return holds_alternative<std::string>(id) ? get<std::string>(id)
+                                            : std::to_string(get<int64_t>(id));
+}
+
+std::future<jsonrpc::Response> makeReadyResponseFuture(
+    const RequestId& id, int code, const std::string& message) {
+  std::promise<jsonrpc::Response> promise;
+  auto future = promise.get_future();
+  promise.set_value(jsonrpc::Response::make_error(id, Error(code, message)));
+  return future;
+}
+
+}  // namespace
 
 namespace {
 
@@ -945,6 +961,82 @@ VoidResult McpServer::sendNotificationToSession(
   }
   return makeVoidError(
       Error(jsonrpc::INTERNAL_ERROR, "No active connection for session"));
+}
+
+VoidResult McpServer::sendRequestToSession(
+    const SessionManager::SessionPtr& session,
+    const jsonrpc::Request& request) {
+  assert(main_dispatcher_ && main_dispatcher_->isThreadSafe() &&
+         "sendRequestToSession off dispatcher");
+
+  if (!session) {
+    return makeVoidError(Error(jsonrpc::INTERNAL_ERROR,
+                               "Cannot send request to missing session"));
+  }
+
+  auto json_val = json::to_json(request);
+  const std::string json_str = json_val.toString();
+
+  if (!session->getTransportSessionId().empty()) {
+    if (!http_sse_factory_) {
+      return makeVoidError(
+          Error(jsonrpc::INTERNAL_ERROR,
+                "No server-initiated request channel on this listener "
+                "(server push requires the built-in HTTP+SSE listener)"));
+    }
+    if (http_sse_factory_->sseRegistry().sendResponse(
+            session->getTransportSessionId(), json_str)) {
+      return makeVoidSuccess();
+    }
+    return makeVoidError(
+        Error(jsonrpc::INTERNAL_ERROR,
+              "SSE stream gone for session " + session->getId()));
+  }
+
+  if (session->getConnection()) {
+    for (auto& conn_manager : connection_managers_) {
+      if (conn_manager->isConnected() &&
+          conn_manager->ownsConnection(session->getConnection())) {
+        return conn_manager->sendRequest(request);
+      }
+    }
+    return makeVoidError(Error(jsonrpc::INTERNAL_ERROR,
+                               "Session " + session->getId() +
+                                   " has no server-initiated request channel"));
+  }
+
+  return makeVoidError(
+      Error(jsonrpc::INTERNAL_ERROR, "No active connection for session"));
+}
+
+std::future<jsonrpc::Response> McpServer::sendRequest(
+    const std::string& session_id, const jsonrpc::Request& request) {
+  if (!main_dispatcher_ || !main_dispatcher_->isThreadSafe()) {
+    return makeReadyResponseFuture(
+        request.id, jsonrpc::INTERNAL_ERROR,
+        "Server-initiated requests must be sent on the MCP dispatcher thread");
+  }
+
+  auto session = session_manager_->getSession(session_id);
+  if (!session) {
+    return makeReadyResponseFuture(request.id, jsonrpc::INVALID_PARAMS,
+                                   "Session not found");
+  }
+
+  auto promise = std::make_shared<std::promise<jsonrpc::Response>>();
+  auto future = promise->get_future();
+  client_requests_.expect(request.id, [promise](const jsonrpc::Response& r) {
+    promise->set_value(r);
+  });
+
+  auto sent = sendRequestToSession(session, request);
+  if (holds_alternative<Error>(sent)) {
+    client_requests_.forget(request.id);
+    promise->set_value(
+        jsonrpc::Response::make_error(request.id, get<Error>(sent)));
+  }
+
+  return future;
 }
 
 // Push notifications/resources/updated to every subscriber of the URI

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -1080,11 +1080,11 @@ std::future<jsonrpc::Response> McpServer::sendRequest(
   auto promise = std::make_shared<std::promise<jsonrpc::Response>>();
   auto future = promise->get_future();
   const RequestIdKey key = requestIdKey(request.id);
-  client_requests_.expect(
-      request.id, [this, key, promise](const jsonrpc::Response& r) {
-        client_request_deadlines_.erase(key);
-        promise->set_value(r);
-      });
+  client_requests_.expect(request.id,
+                          [this, key, promise](const jsonrpc::Response& r) {
+                            client_request_deadlines_.erase(key);
+                            promise->set_value(r);
+                          });
 
   auto sent = sendRequestToSession(session, request);
   if (holds_alternative<Error>(sent)) {

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -15,6 +15,7 @@
 #include "mcp/filter/http_sse_filter_chain_factory.h"
 #include "mcp/filter/json_rpc_filter_factory.h"
 #include "mcp/filter/json_rpc_protocol_filter.h"
+#include "mcp/json/json_serialization.h"
 #include "mcp/filter/sse_session_registry.h"
 #include "mcp/logging/log_macros.h"
 #include "mcp/protocol/modern_era.h"
@@ -31,9 +32,53 @@ namespace mcp {
 namespace server {
 namespace {
 
-std::string requestIdToString(const RequestId& id) {
-  return holds_alternative<std::string>(id) ? get<std::string>(id)
-                                            : std::to_string(get<int64_t>(id));
+constexpr const char* kMcpProtocolVersion2025_03_26 = "2025-03-26";
+constexpr const char* kMcpProtocolVersion2025_11_25 = "2025-11-25";
+
+std::string stringMetadataValue(const Metadata& metadata,
+                                const std::string& key) {
+  auto it = metadata.find(key);
+  if (it == metadata.end() || !holds_alternative<std::string>(it->second)) {
+    return "";
+  }
+  return get<std::string>(it->second);
+}
+
+std::string negotiateProtocolVersion(const std::string& requested,
+                                     const std::string& newest_supported) {
+  if (requested.empty()) {
+    return newest_supported;
+  }
+  if (requested > newest_supported) {
+    return newest_supported;
+  }
+  return requested;
+}
+
+ClientCapabilities clientCapabilitiesFromInitializeParams(
+    const Metadata& params) {
+  ClientCapabilities capabilities;
+  const std::string raw_capabilities =
+      stringMetadataValue(params, "capabilities");
+  if (raw_capabilities.empty()) {
+    return capabilities;
+  }
+  try {
+    const json::JsonValue json = json::JsonValue::parse(raw_capabilities);
+    if (json.isObject()) {
+      capabilities = json::from_json<ClientCapabilities>(json);
+    }
+  } catch (const std::exception&) {
+  }
+  return capabilities;
+}
+
+bool protocolSupportsElicitationMode(const std::string& protocol_version,
+                                     const std::string& mode) {
+  if (mode == "url") {
+    return protocol_version >= kMcpProtocolVersion2025_11_25;
+  }
+  return protocol_version >= kMcpProtocolVersion2025_03_26;
 }
 
 std::future<jsonrpc::Response> makeReadyResponseFuture(
@@ -872,6 +917,11 @@ void McpServer::registerNotificationHandler(
   notification_handlers_[method] = handler;
 }
 
+void McpServer::setInstructions(const std::string& instructions) {
+  std::lock_guard<std::mutex> lock(config_mutex_);
+  config_.instructions = instructions;
+}
+
 // Deliver a notification to one session's client. Dispatcher thread only —
 // every route below writes to a connection owned by that thread.
 VoidResult McpServer::sendNotificationToSession(
@@ -921,7 +971,8 @@ VoidResult McpServer::sendNotificationToSession(
     // delivery.
     return makeVoidError(
         Error(jsonrpc::INTERNAL_ERROR,
-              "SSE stream gone for session " + session->getId()));
+              "SSE stream gone for session " + session->getId() +
+                  " (transport " + session->getTransportSessionId() + ")"));
   }
 
   // Connection-keyed session. Since the dispatch context supplies the
@@ -990,7 +1041,8 @@ VoidResult McpServer::sendRequestToSession(
     }
     return makeVoidError(
         Error(jsonrpc::INTERNAL_ERROR,
-              "SSE stream gone for session " + session->getId()));
+              "SSE stream gone for session " + session->getId() +
+                  " (transport " + session->getTransportSessionId() + ")"));
   }
 
   if (session->getConnection()) {
@@ -1037,6 +1089,25 @@ std::future<jsonrpc::Response> McpServer::sendRequest(
   }
 
   return future;
+}
+
+bool McpServer::sessionSupportsElicitation(
+    const std::string& session_id, const std::string& mode) const {
+  auto session = session_manager_->getSession(session_id);
+  if (!session) {
+    return false;
+  }
+  const auto& elicitation =
+      session->getClientCapabilities().elicitation;
+  if (!elicitation.has_value() ||
+      !protocolSupportsElicitationMode(session->getNegotiatedProtocolVersion(),
+                                       mode)) {
+    return false;
+  }
+  if (mode == "url") {
+    return elicitation->url.has_value();
+  }
+  return elicitation->form.has_value();
 }
 
 // Push notifications/resources/updated to every subscriber of the URI
@@ -2061,19 +2132,40 @@ void McpServer::registerBuiltinHandlers() {
 
 jsonrpc::Response McpServer::handleInitialize(const jsonrpc::Request& request,
                                               SessionContext& session) {
-  // Parse initialize request
-  // TODO: Deserialize InitializeRequest from request.params
-  // TODO: Extract client info and store in session via session.setClientInfo()
+  std::string instructions;
+  std::string protocol_version;
+  std::string server_name;
+  std::string server_version;
+  ServerCapabilities server_capabilities;
+  std::function<std::string(const jsonrpc::Request&, SessionContext&)>
+      instructions_provider;
+  {
+    std::lock_guard<std::mutex> lock(config_mutex_);
+    instructions = config_.instructions;
+    protocol_version = config_.protocol_version;
+    server_name = config_.server_name;
+    server_version = config_.server_version;
+    server_capabilities = config_.capabilities;
+    instructions_provider = config_.instructions_provider;
+  }
 
   // Read the revision the client asked for. Anything missing or of the
   // wrong type leaves this empty, which negotiates to our newest.
   std::string requested_version;
   if (request.params.has_value()) {
-    const auto& params = request.params.value();
-    auto version_it = params.find("protocolVersion");
-    if (version_it != params.end() &&
-        holds_alternative<std::string>(version_it->second)) {
-      requested_version = get<std::string>(version_it->second);
+    auto params = request.params.value();
+    requested_version = stringMetadataValue(params, "protocolVersion");
+    session.setClientCapabilities(clientCapabilitiesFromInitializeParams(params));
+    const std::string raw_client_info = stringMetadataValue(params, "clientInfo");
+    if (!raw_client_info.empty()) {
+      try {
+        const json::JsonValue json = json::JsonValue::parse(raw_client_info);
+        if (json.isObject()) {
+          session.setClientInfo(
+              mcp::make_optional(json::from_json<Implementation>(json)));
+        }
+      } catch (const std::exception&) {
+      }
     }
   }
 
@@ -2088,7 +2180,8 @@ jsonrpc::Response McpServer::handleInitialize(const jsonrpc::Request& request,
   std::vector<std::string> supported = transport::handshakeProtocolVersions(
       transport::servedProtocolVersions(config_.streamable_http));
   if (supported.empty()) {
-    supported.push_back(config_.protocol_version);
+    supported.push_back(protocol_version.empty() ? protocol::kDefaultProtocolVersion
+                                                 : protocol_version);
   }
 
   const std::string negotiated =
@@ -2099,6 +2192,13 @@ jsonrpc::Response McpServer::handleInitialize(const jsonrpc::Request& request,
   // re-deriving it from a header.
   session.setProtocolVersion(negotiated);
 
+  if (instructions_provider) {
+    std::string provided_instructions = instructions_provider(request, session);
+    if (!provided_instructions.empty()) {
+      instructions = std::move(provided_instructions);
+    }
+  }
+
   // Build initialize result as proper nested JSON structure
   // MCP protocol requires nested objects, not flattened dot notation
   json::JsonValue result_json;
@@ -2106,15 +2206,15 @@ jsonrpc::Response McpServer::handleInitialize(const jsonrpc::Request& request,
 
   // Add serverInfo as nested object
   json::JsonValue server_info;
-  server_info["name"] = config_.server_name;
-  server_info["version"] = config_.server_version;
+  server_info["name"] = server_name;
+  server_info["version"] = server_version;
   result_json["serverInfo"] = std::move(server_info);
 
   // Add capabilities as nested object with empty objects for enabled caps
   json::JsonValue capabilities = json::JsonValue::object();
-  if (config_.capabilities.resources.has_value()) {
-    if (holds_alternative<bool>(config_.capabilities.resources.value())) {
-      if (get<bool>(config_.capabilities.resources.value())) {
+  if (server_capabilities.resources.has_value()) {
+    if (holds_alternative<bool>(server_capabilities.resources.value())) {
+      if (get<bool>(server_capabilities.resources.value())) {
         capabilities["resources"] = json::JsonValue::object();
       }
     } else {
@@ -2124,23 +2224,25 @@ jsonrpc::Response McpServer::handleInitialize(const jsonrpc::Request& request,
       capabilities["resources"] = std::move(resources_cap);
     }
   }
-  if (config_.capabilities.tools.has_value() &&
-      config_.capabilities.tools.value()) {
-    capabilities["tools"] = json::JsonValue::object();
+  if (server_capabilities.tools.has_value() &&
+      server_capabilities.tools.value()) {
+    json::JsonValue tools_cap = json::JsonValue::object();
+    tools_cap["listChanged"] = false;
+    capabilities["tools"] = std::move(tools_cap);
   }
-  if (config_.capabilities.prompts.has_value() &&
-      config_.capabilities.prompts.value()) {
+  if (server_capabilities.prompts.has_value() &&
+      server_capabilities.prompts.value()) {
     capabilities["prompts"] = json::JsonValue::object();
   }
-  if (config_.capabilities.logging.has_value() &&
-      config_.capabilities.logging.value()) {
+  if (server_capabilities.logging.has_value() &&
+      server_capabilities.logging.value()) {
     capabilities["logging"] = json::JsonValue::object();
   }
   result_json["capabilities"] = std::move(capabilities);
 
   // Add instructions if present
-  if (!config_.instructions.empty()) {
-    result_json["instructions"] = config_.instructions;
+  if (!instructions.empty()) {
+    result_json["instructions"] = instructions;
   }
 
   // Return response with JSON result directly

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -2282,6 +2282,11 @@ jsonrpc::Response McpServer::handleInitialize(const jsonrpc::Request& request,
 jsonrpc::Response McpServer::handleDiscover(const jsonrpc::Request& request,
                                             SessionContext& session) {
   (void)session;
+  std::string instructions;
+  {
+    std::lock_guard<std::mutex> lock(config_mutex_);
+    instructions = config_.instructions;
+  }
 
   // What a client would otherwise have learned from an introduction. In
   // the era that has none this is the only way to ask, which is why it is
@@ -2301,8 +2306,8 @@ jsonrpc::Response McpServer::handleDiscover(const jsonrpc::Request& request,
 
   result.set("capabilities", json::to_json(config_.capabilities));
 
-  if (!config_.instructions.empty()) {
-    result.set("instructions", json::JsonValue(config_.instructions));
+  if (!instructions.empty()) {
+    result.set("instructions", json::JsonValue(instructions));
   }
 
   // Named under the metadata key rather than as a field of its own: with

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -1035,6 +1035,16 @@ VoidResult McpServer::sendRequestToSession(
                 "No server-initiated request channel on this listener "
                 "(server push requires the built-in HTTP+SSE listener)"));
     }
+    // Streamable HTTP first: its sessions are owned by the session manager, not
+    // the SSE registry used for legacy HTTP+SSE streams.
+    if (auto* sessions = http_sse_factory_->sessionManager()) {
+      const std::string& transport_id = session->getTransportSessionId();
+      if (auto* streamable = sessions->find(transport_id)) {
+        sessions->routeUnsolicited(*streamable, json_str);
+        return makeVoidSuccess();
+      }
+    }
+
     if (http_sse_factory_->sseRegistry().sendResponse(
             session->getTransportSessionId(), json_str)) {
       return makeVoidSuccess();

--- a/tests/filter/test_http_routing_table.cc
+++ b/tests/filter/test_http_routing_table.cc
@@ -40,8 +40,13 @@ class RoutingCallbacks : public McpProtocolCallbacks {
     requests_.push_back(req);
   }
   void onRequestWithContext(const jsonrpc::Request& req,
-                            MessageDispatchContext&) override {
+                            MessageDispatchContext& context) override {
     requests_.push_back(req);
+    jsonrpc::Response response;
+    response.jsonrpc = "2.0";
+    response.id = req.id;
+    response.result = mcp::make_optional(jsonrpc::ResponseResult(Metadata()));
+    context.sendResponse(response);
   }
   void onNotification(const jsonrpc::Notification&) override {}
   void onResponse(const jsonrpc::Response&) override {}
@@ -140,13 +145,15 @@ class HttpRoutingTableTest : public test::RealIoTestBase {
   static std::string request(const std::string& method,
                              const std::string& path,
                              const std::string& body = "",
-                             const std::string& origin = "") {
+                             const std::string& origin = "",
+                             const std::string& extra_headers = "") {
     std::string out = method + " " + path +
                       " HTTP/1.1\r\n"
                       "Host: localhost\r\n";
     if (!origin.empty()) {
       out += "Origin: " + origin + "\r\n";
     }
+    out += extra_headers;
     if (!body.empty()) {
       out += "Content-Type: application/json\r\n";
       out += "Content-Length: " + std::to_string(body.size()) + "\r\n";
@@ -160,6 +167,28 @@ class HttpRoutingTableTest : public test::RealIoTestBase {
     return R"({"jsonrpc":"2.0","method":"initialize","id":1,"params":{)"
            R"("protocolVersion":"2025-06-18","capabilities":{},)"
            R"("clientInfo":{"name":"test","version":"1.0"}}})";
+  }
+
+  static std::string sessionIdOnTheWire(const std::string& wire) {
+    const std::string name = "\r\nMcp-Session-Id: ";
+    const size_t at = wire.find(name);
+    if (at == std::string::npos) {
+      return std::string();
+    }
+    const size_t start = at + name.size();
+    const size_t end = wire.find("\r\n", start);
+    return wire.substr(start, end - start);
+  }
+
+  static size_t countOccurrences(const std::string& haystack,
+                                 const std::string& needle) {
+    size_t count = 0;
+    size_t pos = 0;
+    while ((pos = haystack.find(needle, pos)) != std::string::npos) {
+      ++count;
+      pos += needle.size();
+    }
+    return count;
   }
 
   HttpRoutingFilter* router_{nullptr};
@@ -402,6 +431,41 @@ TEST_F(HttpRoutingTableTest, LegacyEventStreamStillOpens) {
       << "Expected the SSE stream to open, got: " << wire;
   EXPECT_NE(wire.find("text/event-stream"), std::string::npos)
       << "Expected an SSE content type, got: " << wire;
+
+  closeOnDispatcher(std::move(conn), std::move(factory));
+}
+
+TEST_F(HttpRoutingTableTest, StreamableGetRpcIsAnsweredOnlyOnce) {
+  RoutingCallbacks callbacks;
+  std::unique_ptr<network::ServerConnection> conn;
+  network::IoHandlePtr peer;
+  std::shared_ptr<HttpSseFilterChainFactory> factory;
+
+  executeInDispatcher([&]() {
+    auto h = makeServerHarness(callbacks);
+    conn = std::move(h.conn);
+    peer = std::move(h.peer);
+    factory = std::move(h.factory);
+    writeClientBytes(*peer, request("POST", "/mcp", initializeBody()));
+  });
+
+  const std::string init = drainPeer(*peer, 2000ms);
+  const std::string session_id = sessionIdOnTheWire(init);
+  ASSERT_FALSE(session_id.empty()) << init;
+
+  executeInDispatcher([&]() {
+    writeClientBytes(
+        *peer, request("GET", "/mcp", /*body=*/"", /*origin=*/"",
+                       "Accept: text/event-stream\r\n"
+                       "Mcp-Session-Id: " +
+                           session_id + "\r\n"));
+  });
+
+  const std::string wire = drainPeer(*peer, 2000ms);
+  EXPECT_EQ(countOccurrences(wire, "HTTP/1.1 200 OK\r\n"), 1u) << wire;
+  EXPECT_NE(wire.find("Content-Type: text/event-stream"), std::string::npos)
+      << wire;
+  EXPECT_EQ(wire.find("event: endpoint"), std::string::npos) << wire;
 
   closeOnDispatcher(std::move(conn), std::move(factory));
 }

--- a/tests/filter/test_http_routing_table.cc
+++ b/tests/filter/test_http_routing_table.cc
@@ -42,6 +42,7 @@ class RoutingCallbacks : public McpProtocolCallbacks {
   void onRequestWithContext(const jsonrpc::Request& req,
                             MessageDispatchContext& context) override {
     requests_.push_back(req);
+    transport_sessions_.push_back(context.transportSessionId());
     jsonrpc::Response response;
     response.jsonrpc = "2.0";
     response.id = req.id;
@@ -56,6 +57,7 @@ class RoutingCallbacks : public McpProtocolCallbacks {
   bool sendHttpPost(const std::string&) override { return true; }
 
   std::vector<jsonrpc::Request> requests_;
+  std::vector<std::string> transport_sessions_;
 };
 
 class HttpRoutingTableTest : public test::RealIoTestBase {
@@ -466,6 +468,42 @@ TEST_F(HttpRoutingTableTest, StreamableGetRpcIsAnsweredOnlyOnce) {
   EXPECT_NE(wire.find("Content-Type: text/event-stream"), std::string::npos)
       << wire;
   EXPECT_EQ(wire.find("event: endpoint"), std::string::npos) << wire;
+
+  closeOnDispatcher(std::move(conn), std::move(factory));
+}
+
+TEST_F(HttpRoutingTableTest, CallbackSessionDoesNotLeakToNextRequest) {
+  RoutingCallbacks callbacks;
+  std::unique_ptr<network::ServerConnection> conn;
+  network::IoHandlePtr peer;
+  std::shared_ptr<HttpSseFilterChainFactory> factory;
+
+  executeInDispatcher([&]() {
+    auto h = makeServerHarness(callbacks);
+    conn = std::move(h.conn);
+    peer = std::move(h.peer);
+    factory = std::move(h.factory);
+    writeClientBytes(*peer,
+                     request("POST", "/callback/client_1", initializeBody()));
+  });
+
+  std::string callback_ack = drainPeer(*peer, 2000ms);
+  EXPECT_NE(callback_ack.find("HTTP/1.1 202 Accepted"), std::string::npos)
+      << callback_ack;
+  ASSERT_EQ(callbacks.transport_sessions_.size(), 1u);
+  EXPECT_EQ(callbacks.transport_sessions_[0], "client_1");
+
+  executeInDispatcher([&]() {
+    writeClientBytes(*peer, request("POST", "/rpc", initializeBody()));
+  });
+
+  std::string plain_response = drainPeer(*peer, 2000ms);
+  EXPECT_NE(plain_response.find("HTTP/1.1 200 OK"), std::string::npos)
+      << plain_response;
+  ASSERT_EQ(callbacks.transport_sessions_.size(), 2u);
+  EXPECT_TRUE(callbacks.transport_sessions_[1].empty())
+      << "plain keep-alive request reused callback session "
+      << callbacks.transport_sessions_[1];
 
   closeOnDispatcher(std::move(conn), std::move(factory));
 }

--- a/tests/filter/test_http_routing_table.cc
+++ b/tests/filter/test_http_routing_table.cc
@@ -456,11 +456,10 @@ TEST_F(HttpRoutingTableTest, StreamableGetRpcIsAnsweredOnlyOnce) {
   ASSERT_FALSE(session_id.empty()) << init;
 
   executeInDispatcher([&]() {
-    writeClientBytes(
-        *peer, request("GET", "/mcp", /*body=*/"", /*origin=*/"",
-                       "Accept: text/event-stream\r\n"
-                       "Mcp-Session-Id: " +
-                           session_id + "\r\n"));
+    writeClientBytes(*peer, request("GET", "/mcp", /*body=*/"", /*origin=*/"",
+                                    "Accept: text/event-stream\r\n"
+                                    "Mcp-Session-Id: " +
+                                        session_id + "\r\n"));
   });
 
   const std::string wire = drainPeer(*peer, 2000ms);

--- a/tests/filter/test_sse_session_registry.cc
+++ b/tests/filter/test_sse_session_registry.cc
@@ -114,19 +114,6 @@ TEST_F(SseSessionRegistryTest, RegisterReturnsUniqueIds) {
   });
 }
 
-TEST_F(SseSessionRegistryTest, RegisterUsesProvidedSessionId) {
-  executeInDispatcher([this]() {
-    SseSessionRegistry registry(*dispatcher_);
-
-    const std::string id =
-        registry.registerSession("streamable-session", nullptr);
-
-    EXPECT_EQ(id, "streamable-session");
-    EXPECT_EQ(registry.sessionCount(), 1u);
-    EXPECT_TRUE(registry.hasSession("streamable-session"));
-  });
-}
-
 TEST_F(SseSessionRegistryTest, RemoveSessionClearsLookup) {
   executeInDispatcher([this]() {
     SseSessionRegistry registry(*dispatcher_);

--- a/tests/filter/test_sse_session_registry.cc
+++ b/tests/filter/test_sse_session_registry.cc
@@ -114,6 +114,19 @@ TEST_F(SseSessionRegistryTest, RegisterReturnsUniqueIds) {
   });
 }
 
+TEST_F(SseSessionRegistryTest, RegisterUsesProvidedSessionId) {
+  executeInDispatcher([this]() {
+    SseSessionRegistry registry(*dispatcher_);
+
+    const std::string id =
+        registry.registerSession("streamable-session", nullptr);
+
+    EXPECT_EQ(id, "streamable-session");
+    EXPECT_EQ(registry.sessionCount(), 1u);
+    EXPECT_TRUE(registry.hasSession("streamable-session"));
+  });
+}
+
 TEST_F(SseSessionRegistryTest, RemoveSessionClearsLookup) {
   executeInDispatcher([this]() {
     SseSessionRegistry registry(*dispatcher_);

--- a/tests/integration/test_server_notification_delivery.cc
+++ b/tests/integration/test_server_notification_delivery.cc
@@ -595,8 +595,9 @@ TEST_F(ServerNotificationDeliveryTest, SendRequestReachesStreamableHttpClient) {
   auto server_answer_future = server_answer.get_future();
   server_->registerRequestHandler(
       "test/capture",
-      [this, &server_answer](const jsonrpc::Request& request,
-                             server::SessionContext& session) -> jsonrpc::Response {
+      [this, &server_answer](
+          const jsonrpc::Request& request,
+          server::SessionContext& session) -> jsonrpc::Response {
         jsonrpc::Request question;
         question.jsonrpc = "2.0";
         question.id = std::string("server-question-1");

--- a/tests/integration/test_server_notification_delivery.cc
+++ b/tests/integration/test_server_notification_delivery.cc
@@ -209,6 +209,47 @@ class ServerNotificationDeliveryTest : public ::testing::Test {
     return clients_.back().get();
   }
 
+  client::McpClient* makeConnectedStreamableClient(const std::string& name) {
+    client::McpClientConfig client_config;
+    client_config.client_name = name;
+    client_config.client_version = "0.0.1";
+    client_config.num_workers = 1;
+    client_config.preferred_transport = TransportType::StreamableHttp;
+    client_config.request_timeout = 5000ms;
+    client_config.protocol_initialization_timeout = 5000ms;
+    client_config.protocol_connection_timeout = 5000ms;
+    client_config.streamable_http.open_server_stream = true;
+
+    auto client = client::createMcpClient(client_config);
+    if (!client) {
+      ADD_FAILURE() << "createMcpClient returned null";
+      return nullptr;
+    }
+
+    const std::string uri =
+        "http://127.0.0.1:" + std::to_string(port_) + "/mcp";
+    auto connect_result = client->connect(uri);
+    if (!holds_alternative<std::nullptr_t>(connect_result)) {
+      ADD_FAILURE() << "McpClient::connect failed against Streamable HTTP";
+      return nullptr;
+    }
+
+    auto init_future = client->initializeProtocol();
+    if (init_future.wait_for(5s) != std::future_status::ready) {
+      ADD_FAILURE() << "initialize never round-tripped over Streamable HTTP";
+      return nullptr;
+    }
+    try {
+      init_future.get();
+    } catch (const std::exception& e) {
+      ADD_FAILURE() << "initialize failed: " << e.what();
+      return nullptr;
+    }
+
+    clients_.push_back(std::move(client));
+    return clients_.back().get();
+  }
+
   // Subscribe a client to a resource and require the ack round trip.
   static bool subscribeAndWait(client::McpClient& client,
                                const std::string& uri) {
@@ -547,6 +588,55 @@ TEST_F(ServerNotificationDeliveryTest, SendNotificationOffThreadDelivers) {
   ASSERT_EQ(delivered_future.wait_for(5s), std::future_status::ready)
       << "off-thread sendNotification never reached the client";
   EXPECT_EQ(delivered_future.get(), "offthread");
+}
+
+TEST_F(ServerNotificationDeliveryTest, SendRequestReachesStreamableHttpClient) {
+  std::promise<std::future<jsonrpc::Response>> server_answer;
+  auto server_answer_future = server_answer.get_future();
+  server_->registerRequestHandler(
+      "test/capture",
+      [this, &server_answer](const jsonrpc::Request& request,
+                             server::SessionContext& session) -> jsonrpc::Response {
+        jsonrpc::Request question;
+        question.jsonrpc = "2.0";
+        question.id = std::string("server-question-1");
+        question.method = "test/server-question";
+
+        server_answer.set_value(
+            server_->sendRequest(session.getId(), question, 5000ms));
+        return jsonrpc::Response::success(
+            request.id, jsonrpc::ResponseResult(make<Metadata>().build()));
+      });
+
+  auto* client = makeConnectedStreamableClient("server-request-client");
+  ASSERT_NE(client, nullptr);
+  client->registerRequestHandler(
+      "test/server-question",
+      [](const jsonrpc::Request&) -> jsonrpc::ResponseResult {
+        Metadata result;
+        result["answer"] = std::string("pong");
+        return result;
+      });
+
+  auto trigger = client->sendRequest("test/capture");
+  ASSERT_EQ(trigger.wait_for(5s), std::future_status::ready)
+      << "trigger request never completed";
+  ASSERT_NO_THROW(trigger.get());
+
+  ASSERT_EQ(server_answer_future.wait_for(5s), std::future_status::ready)
+      << "server handler never attempted sendRequest";
+  auto response_future = server_answer_future.get();
+  ASSERT_EQ(response_future.wait_for(5s), std::future_status::ready)
+      << "server-initiated request never received a client answer";
+
+  const jsonrpc::Response response = response_future.get();
+  ASSERT_TRUE(response.result.has_value()) << "client returned an error";
+  ASSERT_TRUE(holds_alternative<Metadata>(*response.result));
+  const auto& result = get<Metadata>(*response.result);
+  auto answer = result.find("answer");
+  ASSERT_NE(answer, result.end());
+  ASSERT_TRUE(holds_alternative<std::string>(answer->second));
+  EXPECT_EQ(get<std::string>(answer->second), "pong");
 }
 }  // namespace
 }  // namespace mcp

--- a/tests/integration/test_sse_transport_round_trip.cc
+++ b/tests/integration/test_sse_transport_round_trip.cc
@@ -371,8 +371,7 @@ TEST_F(SseTransportRoundTripTest,
             std::string::npos)
       << "streamable GET did not open an event stream: " << handshake;
   EXPECT_NE(handshake.find(": stream open\n\n"), std::string::npos)
-      << "streamable GET did not send the initial open comment: "
-      << handshake;
+      << "streamable GET did not send the initial open comment: " << handshake;
   EXPECT_EQ(handshake.find("event: endpoint"), std::string::npos)
       << "streamable GET must not use legacy endpoint negotiation: "
       << handshake;

--- a/tests/integration/test_sse_transport_round_trip.cc
+++ b/tests/integration/test_sse_transport_round_trip.cc
@@ -40,6 +40,7 @@
  */
 
 #include <chrono>
+#include <cstdlib>
 #include <regex>
 #include <string>
 #include <thread>
@@ -181,6 +182,48 @@ class SseTransportRoundTripTest : public test::RealIoTestBase {
       }
     }
     return out;
+  }
+
+  static int statusOf(const std::string& response) {
+    if (response.compare(0, 9, "HTTP/1.1 ") != 0) {
+      return 0;
+    }
+    return std::atoi(response.c_str() + 9);
+  }
+
+  static std::string headerOf(const std::string& response,
+                              const std::string& name) {
+    const std::string needle = "\r\n" + name + ": ";
+    const size_t at = response.find(needle);
+    if (at == std::string::npos) {
+      return std::string();
+    }
+    const size_t start = at + needle.size();
+    return response.substr(start, response.find("\r\n", start) - start);
+  }
+
+  std::string createStreamableSession(
+      const std::shared_ptr<filter::HttpSseFilterChainFactory>& factory) {
+    auto* sessions = factory->sessionManager();
+    EXPECT_NE(sessions, nullptr);
+    if (sessions == nullptr) {
+      return std::string();
+    }
+    auto* session =
+        sessions->createSession(*dispatcher_, /*principal=*/"anonymous");
+    EXPECT_NE(session, nullptr);
+    return session != nullptr ? session->id : std::string();
+  }
+
+  void pushStreamableMessage(
+      const std::shared_ptr<filter::HttpSseFilterChainFactory>& factory,
+      const std::string& session_id,
+      const std::string& payload) {
+    auto* sessions = factory->sessionManager();
+    ASSERT_NE(sessions, nullptr);
+    auto* session = sessions->find(session_id);
+    ASSERT_NE(session, nullptr);
+    sessions->routeUnsolicited(*session, payload);
   }
 
   // Tear down the connection and factory on the dispatcher thread.
@@ -349,14 +392,19 @@ TEST_F(SseTransportRoundTripTest,
   std::unique_ptr<network::ServerConnection> conn;
   network::IoHandlePtr peer;
   std::shared_ptr<filter::HttpSseFilterChainFactory> factory;
-  const std::string session_id = "streamable_postman";
+  std::string session_id;
 
   executeInDispatcher([&]() {
     auto h = makeHarness(callbacks);
     conn = std::move(h.conn);
     peer = std::move(h.peer);
     factory = std::move(h.factory);
+    session_id = createStreamableSession(factory);
+  });
 
+  ASSERT_FALSE(session_id.empty());
+
+  executeInDispatcher([&]() {
     std::string req;
     req += "GET /mcp HTTP/1.1\r\n";
     req += "Host: localhost\r\n";
@@ -367,11 +415,10 @@ TEST_F(SseTransportRoundTripTest,
   });
 
   const std::string handshake = drainPeer(*peer);
-  EXPECT_NE(handshake.find("Content-Type: text/event-stream"),
-            std::string::npos)
+  EXPECT_EQ(statusOf(handshake), 200)
+      << "streamable GET did not return 200: " << handshake;
+  EXPECT_EQ(headerOf(handshake, "Content-Type"), "text/event-stream")
       << "streamable GET did not open an event stream: " << handshake;
-  EXPECT_NE(handshake.find(": stream open\n\n"), std::string::npos)
-      << "streamable GET did not send the initial open comment: " << handshake;
   EXPECT_EQ(handshake.find("event: endpoint"), std::string::npos)
       << "streamable GET must not use legacy endpoint negotiation: "
       << handshake;
@@ -379,7 +426,7 @@ TEST_F(SseTransportRoundTripTest,
   executeInDispatcher([&]() {
     const std::string payload =
         R"({"jsonrpc":"2.0","id":"elicit-1","method":"elicitation/create","params":{"mode":"url","url":"https://auth.example/authorize"}})";
-    ASSERT_TRUE(factory->sseRegistry().sendResponse(session_id, payload));
+    pushStreamableMessage(factory, session_id, payload);
   });
 
   const std::string pushed = drainPeer(*peer);
@@ -401,14 +448,19 @@ TEST_F(SseTransportRoundTripTest,
   std::unique_ptr<network::ServerConnection> conn;
   network::IoHandlePtr peer;
   std::shared_ptr<filter::HttpSseFilterChainFactory> factory;
-  const std::string session_id = "streamable_after_post";
+  std::string session_id;
 
   executeInDispatcher([&]() {
     auto h = makeHarness(callbacks);
     conn = std::move(h.conn);
     peer = std::move(h.peer);
     factory = std::move(h.factory);
+    session_id = createStreamableSession(factory);
+  });
 
+  ASSERT_FALSE(session_id.empty());
+
+  executeInDispatcher([&]() {
     const std::string body =
         R"({"jsonrpc":"2.0","method":"notifications/initialized"})";
     std::string post;
@@ -438,18 +490,21 @@ TEST_F(SseTransportRoundTripTest,
   });
 
   const std::string handshake = drainPeer(*peer);
-  EXPECT_NE(handshake.find("Content-Type: text/event-stream"),
-            std::string::npos)
+  EXPECT_EQ(statusOf(handshake), 200)
+      << "streamable GET after keep-alive POST did not return 200: "
+      << handshake;
+  EXPECT_EQ(headerOf(handshake, "Content-Type"), "text/event-stream")
       << "streamable GET after keep-alive POST did not open an event stream: "
       << handshake;
-  EXPECT_NE(handshake.find(": stream open\n\n"), std::string::npos)
-      << "streamable GET after keep-alive POST did not send open comment: "
+  EXPECT_EQ(handshake.find("event: endpoint"), std::string::npos)
+      << "streamable GET after keep-alive POST must not use legacy endpoint "
+         "negotiation: "
       << handshake;
 
   executeInDispatcher([&]() {
     const std::string payload =
         R"({"jsonrpc":"2.0","id":"elicit-1","method":"elicitation/create","params":{"mode":"url","url":"https://auth.example/authorize"}})";
-    ASSERT_TRUE(factory->sseRegistry().sendResponse(session_id, payload));
+    pushStreamableMessage(factory, session_id, payload);
   });
 
   const std::string pushed = drainPeer(*peer);

--- a/tests/integration/test_sse_transport_round_trip.cc
+++ b/tests/integration/test_sse_transport_round_trip.cc
@@ -48,6 +48,7 @@
 
 #include "mcp/buffer.h"
 #include "mcp/filter/http_sse_filter_chain_factory.h"
+#include "mcp/filter/sse_session_registry.h"
 #include "mcp/mcp_connection_manager.h"
 #include "mcp/network/connection_impl.h"
 #include "mcp/network/socket_impl.h"
@@ -337,6 +338,127 @@ TEST_F(SseTransportRoundTripTest, ConfiguredSsePathIsHonored) {
       << "configured SSE path /events did not return 200, got: " << wire;
   EXPECT_NE(wire.find("event: endpoint"), std::string::npos)
       << "no endpoint event on configured /events path, got: " << wire;
+
+  closeOnDispatcher(std::move(conn), std::move(factory));
+}
+
+TEST_F(SseTransportRoundTripTest,
+       StreamableHttpPushUsesSseEventNotNestedHttpResponse) {
+  RecordingCallbacks callbacks;
+
+  std::unique_ptr<network::ServerConnection> conn;
+  network::IoHandlePtr peer;
+  std::shared_ptr<filter::HttpSseFilterChainFactory> factory;
+  const std::string session_id = "streamable_postman";
+
+  executeInDispatcher([&]() {
+    auto h = makeHarness(callbacks);
+    conn = std::move(h.conn);
+    peer = std::move(h.peer);
+    factory = std::move(h.factory);
+
+    std::string req;
+    req += "GET /mcp HTTP/1.1\r\n";
+    req += "Host: localhost\r\n";
+    req += "Accept: text/event-stream\r\n";
+    req += "Mcp-Session-Id: " + session_id + "\r\n";
+    req += "\r\n";
+    writeClientBytes(*peer, req);
+  });
+
+  const std::string handshake = drainPeer(*peer);
+  EXPECT_NE(handshake.find("Content-Type: text/event-stream"),
+            std::string::npos)
+      << "streamable GET did not open an event stream: " << handshake;
+  EXPECT_NE(handshake.find(": stream open\n\n"), std::string::npos)
+      << "streamable GET did not send the initial open comment: "
+      << handshake;
+  EXPECT_EQ(handshake.find("event: endpoint"), std::string::npos)
+      << "streamable GET must not use legacy endpoint negotiation: "
+      << handshake;
+
+  executeInDispatcher([&]() {
+    const std::string payload =
+        R"({"jsonrpc":"2.0","id":"elicit-1","method":"elicitation/create","params":{"mode":"url","url":"https://auth.example/authorize"}})";
+    ASSERT_TRUE(factory->sseRegistry().sendResponse(session_id, payload));
+  });
+
+  const std::string pushed = drainPeer(*peer);
+  EXPECT_NE(pushed.find("data: {\"jsonrpc\":\"2.0\""), std::string::npos)
+      << "server push was not framed as an SSE event: " << pushed;
+  EXPECT_NE(pushed.find("\"method\":\"elicitation/create\""), std::string::npos)
+      << "server push did not contain elicitation request: " << pushed;
+  EXPECT_EQ(pushed.find("HTTP/1.1"), std::string::npos)
+      << "server push was nested as an HTTP response inside SSE body: "
+      << pushed;
+
+  closeOnDispatcher(std::move(conn), std::move(factory));
+}
+
+TEST_F(SseTransportRoundTripTest,
+       StreamableHttpGetCanFollowPlainHttpKeepAliveRequest) {
+  RecordingCallbacks callbacks;
+
+  std::unique_ptr<network::ServerConnection> conn;
+  network::IoHandlePtr peer;
+  std::shared_ptr<filter::HttpSseFilterChainFactory> factory;
+  const std::string session_id = "streamable_after_post";
+
+  executeInDispatcher([&]() {
+    auto h = makeHarness(callbacks);
+    conn = std::move(h.conn);
+    peer = std::move(h.peer);
+    factory = std::move(h.factory);
+
+    const std::string body =
+        R"({"jsonrpc":"2.0","method":"notifications/initialized"})";
+    std::string post;
+    post += "POST /mcp HTTP/1.1\r\n";
+    post += "Host: localhost\r\n";
+    post += "Content-Type: application/json\r\n";
+    post += "Connection: keep-alive\r\n";
+    post += "Content-Length: " + std::to_string(body.size()) + "\r\n";
+    post += "\r\n";
+    post += body;
+    writeClientBytes(*peer, post);
+  });
+
+  const std::string accepted = drainPeer(*peer);
+  EXPECT_NE(accepted.find("HTTP/1.1 202"), std::string::npos)
+      << "plain HTTP notification did not complete on keep-alive socket: "
+      << accepted;
+
+  executeInDispatcher([&]() {
+    std::string get;
+    get += "GET /mcp HTTP/1.1\r\n";
+    get += "Host: localhost\r\n";
+    get += "Accept: text/event-stream\r\n";
+    get += "Mcp-Session-Id: " + session_id + "\r\n";
+    get += "\r\n";
+    writeClientBytes(*peer, get);
+  });
+
+  const std::string handshake = drainPeer(*peer);
+  EXPECT_NE(handshake.find("Content-Type: text/event-stream"),
+            std::string::npos)
+      << "streamable GET after keep-alive POST did not open an event stream: "
+      << handshake;
+  EXPECT_NE(handshake.find(": stream open\n\n"), std::string::npos)
+      << "streamable GET after keep-alive POST did not send open comment: "
+      << handshake;
+
+  executeInDispatcher([&]() {
+    const std::string payload =
+        R"({"jsonrpc":"2.0","id":"elicit-1","method":"elicitation/create","params":{"mode":"url","url":"https://auth.example/authorize"}})";
+    ASSERT_TRUE(factory->sseRegistry().sendResponse(session_id, payload));
+  });
+
+  const std::string pushed = drainPeer(*peer);
+  EXPECT_NE(pushed.find("data: {\"jsonrpc\":\"2.0\""), std::string::npos)
+      << "server push after keep-alive POST was not routed to SSE: " << pushed;
+  EXPECT_NE(pushed.find("\"method\":\"elicitation/create\""), std::string::npos)
+      << "server push after keep-alive POST lost elicitation payload: "
+      << pushed;
 
   closeOnDispatcher(std::move(conn), std::move(factory));
 }

--- a/tests/json/test_mcp_serialization.cc
+++ b/tests/json/test_mcp_serialization.cc
@@ -761,8 +761,19 @@ TEST_F(MCPSerializationTest, ClientCapabilities) {
   // Add roots capability
   caps.roots = mcp::make_optional(RootsCapability());
   caps.roots->listChanged = mcp::make_optional(EmptyCapability());
+  caps.elicitation = mcp::make_optional(ElicitationCapability());
+  caps.elicitation->url = mcp::make_optional(EmptyCapability());
 
   testRoundTrip(caps);
+
+  JsonValue json = to_json(caps);
+  ASSERT_TRUE(json.contains("elicitation"));
+  EXPECT_TRUE(json["elicitation"].isObject());
+  EXPECT_TRUE(json["elicitation"].contains("url"));
+
+  ClientCapabilities decoded = from_json<ClientCapabilities>(json);
+  EXPECT_TRUE(decoded.elicitation.has_value());
+  EXPECT_TRUE(decoded.elicitation->url.has_value());
 }
 
 TEST_F(MCPSerializationTest, ServerCapabilities) {

--- a/tests/server/test_mcp_server_responses.cc
+++ b/tests/server/test_mcp_server_responses.cc
@@ -34,7 +34,9 @@ TEST_F(McpServerResponseTest, InitializeResponseFormat) {
   result_json["serverInfo"] = std::move(server_info);
 
   JsonValue capabilities = JsonValue::object();
-  capabilities["tools"] = JsonValue::object();
+  JsonValue tools_capability = JsonValue::object();
+  tools_capability["listChanged"] = false;
+  capabilities["tools"] = std::move(tools_capability);
   capabilities["prompts"] = JsonValue::object();
   result_json["capabilities"] = std::move(capabilities);
 
@@ -53,8 +55,9 @@ TEST_F(McpServerResponseTest, InitializeResponseFormat) {
       << "serverInfo should be nested object, got: " << json_str;
   EXPECT_TRUE(json_str.find("\"capabilities\":{") != std::string::npos)
       << "capabilities should be nested object";
-  EXPECT_TRUE(json_str.find("\"tools\":{}") != std::string::npos)
-      << "tools should be empty object";
+  EXPECT_TRUE(json_str.find("\"tools\":{\"listChanged\":false}") !=
+              std::string::npos)
+      << "tools should advertise listChanged support shape";
   EXPECT_TRUE(json_str.find("\"prompts\":{}") != std::string::npos)
       << "prompts should be empty object";
 


### PR DESCRIPTION
## Summary
  - Streamable server request support
  - Add Streamable HTTP elicitation routing over the client event stream
  - Preserve keep-alive behavior when `notifications/initialized` is followed by a Streamable HTTP GET
  - Add/port regression coverage for SSE session routing, elicitation capability serialization, and server response behavior