### PR TITLE
Fix use-after-free in connection teardown; let a server advertise tools.listChanged

### DIFF
--- a/include/mcp/network/connection.h
+++ b/include/mcp/network/connection.h
@@ -466,7 +466,6 @@ class ConnectionImplBase : public virtual Connection {
   SocketPtr socket_;
   TransportSocketPtr transport_socket_;
   stream_info::StreamInfoSharedPtr stream_info_;
-  FilterManagerImpl filter_manager_;
 
   // State machine for managing connection lifecycle
   std::unique_ptr<ConnectionStateMachine> state_machine_;
@@ -506,6 +505,17 @@ class ConnectionImplBase : public virtual Connection {
 
   // File events
   event::FileEventPtr file_event_;
+
+  // Declared LAST so it is destroyed FIRST. Members die in reverse
+  // declaration order, and a filter's destructor may reach back into the
+  // connection that owns it — HttpSseJsonRpcProtocolFilter's destructor
+  // calls removeConnectionCallbacks() on this connection. Declared before
+  // callbacks_, the callback list was already destroyed by the time the
+  // filters ran, so that unregister walked a freed std::list and segfaulted
+  // on the dispatcher thread during deferred connection delete. Keeping the
+  // filter manager last means every member a filter might touch on the way
+  // out is still alive when it does.
+  FilterManagerImpl filter_manager_;
 
   // Connection ID generator
   static std::atomic<uint64_t> next_connection_id_;

--- a/include/mcp/network/connection.h
+++ b/include/mcp/network/connection.h
@@ -508,7 +508,7 @@ class ConnectionImplBase : public virtual Connection {
 
   // Declared LAST so it is destroyed FIRST. Members die in reverse
   // declaration order, and a filter's destructor may reach back into the
-  // connection that owns it — HttpSseJsonRpcProtocolFilter's destructor
+  // connection that owns it: HttpSseJsonRpcProtocolFilter's destructor
   // calls removeConnectionCallbacks() on this connection. Declared before
   // callbacks_, the callback list was already destroyed by the time the
   // filters ran, so that unregister walked a freed std::list and segfaulted

--- a/include/mcp/server/mcp_server.h
+++ b/include/mcp/server/mcp_server.h
@@ -91,6 +91,16 @@ struct McpServerConfig : public application::ApplicationBase::Config {
   std::function<std::string(const jsonrpc::Request&, SessionContext&)>
       instructions_provider;
 
+  // Whether the tools capability advertises listChanged. Default false, which
+  // is what a server whose tool set is fixed at startup should say.
+  //
+  // A server that discovers tools after initialize -- an aggregator whose
+  // backends come online later, say -- must advertise true, or clients have
+  // no reason to re-list and will show whatever was available at connect
+  // time forever. Such a server is expected to actually send
+  // notifications/tools/list_changed when its set changes.
+  bool tools_list_changed = false;
+
   // Transport configuration
   std::vector<TransportType> supported_transports = {TransportType::Stdio,
                                                      TransportType::HttpSse};

--- a/src/network/connection_impl.cc
+++ b/src/network/connection_impl.cc
@@ -33,14 +33,16 @@ ConnectionImplBase::ConnectionImplBase(event::Dispatcher& dispatcher,
       socket_(std::move(socket)),
       transport_socket_(std::move(transport_socket)),
       stream_info_(std::make_shared<stream_info::StreamInfoImpl>()),
-      filter_manager_(*this, dispatcher),
       id_(next_connection_id_++),
       read_buffer_([this]() { return onReadBufferLowWatermark(); },
                    [this]() { return onReadBufferHighWatermark(); },
                    []() { return false; }),  // below overflow not used for read
       write_buffer_([this]() { return onWriteBufferLowWatermark(); },
                     [this]() { return onWriteBufferHighWatermark(); },
-                    [this]() { return onWriteBufferBelowLowWatermark(); }) {
+                    [this]() { return onWriteBufferBelowLowWatermark(); }),
+      // Initialised last to match its declaration order; see the comment on
+      // the member for why it must be declared last (destroyed first).
+      filter_manager_(*this, dispatcher) {
   // Initialize connection state machine
   state_machine_ = std::make_unique<ConnectionStateMachine>(dispatcher);
 

--- a/src/server/mcp_server.cc
+++ b/src/server/mcp_server.cc
@@ -2396,7 +2396,10 @@ jsonrpc::Response McpServer::handleInitialize(const jsonrpc::Request& request,
   if (server_capabilities.tools.has_value() &&
       server_capabilities.tools.value()) {
     json::JsonValue tools_cap = json::JsonValue::object();
-    tools_cap["listChanged"] = false;
+    // Honour what the server was configured to promise. Hardcoding false
+    // meant an aggregator that gains tools after initialize had no way to
+    // tell clients to look again.
+    tools_cap["listChanged"] = config_.tools_list_changed;
     capabilities["tools"] = std::move(tools_cap);
   }
   if (server_capabilities.prompts.has_value() &&

--- a/tests/server/test_empty_result_shape.cc
+++ b/tests/server/test_empty_result_shape.cc
@@ -207,6 +207,53 @@ TEST(ToolDesignations, AnUnusableDefinitionIsRefusedAndTheRestAreServed) {
       << "a refused tool was listed anyway: " << wire;
 }
 
+// A server whose tool set is fixed says so, and one that discovers tools later
+// says the opposite. Asserted through a real initialize rather than a
+// hand-built JSON blob, so that the capability stays wired to the config: an
+// aggregator that stopped advertising listChanged would leave every client
+// showing whatever existed at connect time, with nothing failing to say so.
+jsonrpc::Request initializeRequest(int64_t id) {
+  jsonrpc::Request request;
+  request.jsonrpc = "2.0";
+  request.id = make_request_id(id);
+  request.method = "initialize";
+  Metadata params;
+  params["protocolVersion"] = MetadataValue(std::string("2025-03-26"));
+  request.params = mcp::make_optional(params);
+  return request;
+}
+
+TEST(InitializeCapabilities, AFixedToolSetSaysItDoesNotChange) {
+  McpServerConfig config = testConfig();
+  config.capabilities.tools = mcp::make_optional(true);
+  DispatchTestServer server(config);
+  CapturingContext context;
+
+  server.onRequestWithContext(initializeRequest(1), context);
+
+  ASSERT_TRUE(context.captured.has_value()) << "initialize went unanswered";
+  const std::string wire = context.wire();
+  EXPECT_NE(wire.find("\"listChanged\":false"), std::string::npos)
+      << "a server that never gains tools claimed it might: " << wire;
+}
+
+TEST(InitializeCapabilities, AServerThatGainsToolsLaterSaysSo) {
+  McpServerConfig config = testConfig();
+  config.capabilities.tools = mcp::make_optional(true);
+  config.tools_list_changed = true;
+  DispatchTestServer server(config);
+  CapturingContext context;
+
+  server.onRequestWithContext(initializeRequest(1), context);
+
+  ASSERT_TRUE(context.captured.has_value()) << "initialize went unanswered";
+  const std::string wire = context.wire();
+  EXPECT_NE(wire.find("\"listChanged\":true"), std::string::npos)
+      << "a server configured to gain tools did not advertise it, so no client "
+         "will ever re-list: "
+      << wire;
+}
+
 }  // namespace
 }  // namespace server
 }  // namespace mcp


### PR DESCRIPTION
Two defects found while debugging a hosted MCP gateway that was CrashLooping
and stalling on a test cluster. Detail, repro and verification:
**GopherSecurity/gopher-issue#1343**

## 1. Use-after-free during connection teardown

`ConnectionImplBase` declared `filter_manager_` **before** `callbacks_`. Members
die in reverse declaration order, so `callbacks_` was destroyed first — and then
`filter_manager_` destroyed `HttpSseJsonRpcProtocolFilter`, whose destructor
calls `removeConnectionCallbacks()` on the connection and walked a freed
`std::list`.

Symbolised from a real pod backtrace:

```
McpServer::run() → LibeventDispatcher::runDeferredDeletes()
  → ConnectionImpl::~ConnectionImpl() → ConnectionImplBase::~ConnectionImplBase()
    → FilterManagerImpl::~FilterManagerImpl() → ~HttpSseJsonRpcProtocolFilter()
      → ConnectionImplBase::removeConnectionCallbacks()   ← SIGSEGV
```

The filter's destructor arrived with 80c51cbd (#269); before it nothing reached
back into the dying connection. Being UB, it was fatal under glibc on x86-64 and
silent on arm64 — the gateway died on the cluster while every local test passed.

**Fix:** declare `filter_manager_` last so it is destroyed first, with the
constructor init list moved to match.

## 2. `tools.listChanged` hardcoded `false`

```cpp
tools_cap["listChanged"] = false;   // regardless of configuration
```

Correct for a server whose tool set is fixed at startup; wrong for an aggregator
that discovers backends after `initialize` — it had no way to tell clients to
re-list, so they showed connect-time tools forever.

**Fix:** `McpServerConfig::tools_list_changed`, defaulting to `false` so no
existing server reports differently.

## Verification

- Segfault reproduced **3/3** running the image as `linux/amd64`, **0/3** after
  the fix, then confirmed on the cluster: 0 crashes and 0 restarts across
  repeated redeploys where it previously CrashLooped every time
- `initialize` returns `{"listChanged": true}` when a server opts in, and
  `notifications/tools/list_changed` observed on the wire after background
  discovery
- Downstream consumer: `GatewayServerTest` 163/163 across three consecutive
  runs, `auth_test` 425/425

## Note for reviewers

`fix/concurrent-response-routing` (d8a4b667, June — "fix concurrent-request
hangs") never merged to `main` and is now 9 commits behind 277. The
`current_connection_` mechanism it patched no longer exists; responses are bound
per dispatch via `ResponseStream`. It is superseded rather than pending, and
probably worth closing so it stops reading as a lost fix.
